### PR TITLE
Release v4.7.0: Extend multi-battery support to 6 batteries (M5-M6)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,16 @@
 # Release Notes
 All releases follow Semantic Versioning (SemVer). Every release provides a fresh `home assistant/dashboard.yaml` to import.
 
+## 4.7.0
+- **Feat: Multi-battery support extended from 4 to 6 (M5–M6) — fixes #103**
+  * HBC now supports up to 6 batteries (M1–M6) out of the box with glance cards and per-battery configuration grids.
+  * Three phase homes using 2 batteries per phase, can now use HBC without modification.
+  * Thanks to _nickles-lee_ for the PR (#104) and _Stievo9997_ for field-testing with 6 batteries.
+
+- **Files Changed:**
+  - `home assistant/dashboard.yaml`
+  - `home assistant/packages/house_battery_control.yaml`
+
 ## 4.6.3
 - **Fix: EV trigger template fallback**
   * Fixed a bug in the EV is charging template using an undefined variable `bron_entity_id`.

--- a/docs/06-advanced-features.md
+++ b/docs/06-advanced-features.md
@@ -46,8 +46,8 @@ nav_order: 6
   - Note: the SET MODE action nodes have proven unreliable, for _safety reasons_ the `On Change` RBE has been left out.
 
 ## Multi-Battery Management
-- **More than 4 batteries:** Override or change `input_number.house_battery_count` and you are good to go.
-  - The dashboard supports 4 batteries out of the box, duplicate and edit these or create your own dashboard.
+- **More than 6 batteries:** Override or change `input_number.house_battery_count` and you are good to go.
+  - The dashboard supports 6 batteries out of the box. For 7 or more, duplicate and edit these cards or create your own dashboard.
 - **3-Phase self-consumption:** if you require 0 W grid consumption on a per phase basis, the setup changes slightly. 
       
       Note: most homes get billed for the net total of all phases. If that is the case for you as well, ignore these instructions.

--- a/home assistant/dashboard.yaml
+++ b/home assistant/dashboard.yaml
@@ -1,4 +1,4 @@
-views:
+﻿views:
   - type: sections
     path: home-battery-control
     max_columns: 3
@@ -346,6 +346,10 @@ views:
                 name: M3
               - entity: select.marstek_m4_forcible_charge_discharge
                 name: M4
+              - entity: select.marstek_m5_forcible_charge_discharge
+                name: M5
+              - entity: select.marstek_m6_forcible_charge_discharge
+                name: M6
             hours_to_show: 0.05
           - type: heading
             icon: mdi:information
@@ -524,6 +528,70 @@ views:
                     entity: input_number.house_battery_count
                     above: 3
           - type: heading
+            heading: Marstek M5
+            heading_style: subtitle
+            icon: ''
+            visibility:
+              - condition: and
+                conditions:
+                  - condition: state
+                    entity: sensor.marstek_m5_device_name
+                    state_not: unknown
+                  - condition: numeric_state
+                    entity: input_number.house_battery_count
+                    above: 4
+          - type: glance
+            entities:
+              - entity: sensor.marstek_m5_battery_state_of_charge
+                name: M5 SoC
+              - entity: sensor.marstek_m5_ac_power
+                name: M5 Power
+              - entity: number.marstek_m5_max_charge_power
+                name: Max Charge
+              - entity: number.marstek_m5_max_discharge_power
+                name: Max Discharge
+            visibility:
+              - condition: and
+                conditions:
+                  - condition: state
+                    entity: sensor.marstek_m5_device_name
+                    state_not: unknown
+                  - condition: numeric_state
+                    entity: input_number.house_battery_count
+                    above: 4
+          - type: heading
+            heading: Marstek M6
+            heading_style: subtitle
+            icon: ''
+            visibility:
+              - condition: and
+                conditions:
+                  - condition: state
+                    entity: sensor.marstek_m6_device_name
+                    state_not: unknown
+                  - condition: numeric_state
+                    entity: input_number.house_battery_count
+                    above: 5
+          - type: glance
+            entities:
+              - entity: sensor.marstek_m6_battery_state_of_charge
+                name: M6 SoC
+              - entity: sensor.marstek_m6_ac_power
+                name: M6 Power
+              - entity: number.marstek_m6_max_charge_power
+                name: Max Charge
+              - entity: number.marstek_m6_max_discharge_power
+                name: Max Discharge
+            visibility:
+              - condition: and
+                conditions:
+                  - condition: state
+                    entity: sensor.marstek_m6_device_name
+                    state_not: unknown
+                  - condition: numeric_state
+                    entity: input_number.house_battery_count
+                    above: 5
+          - type: heading
             heading: Info and guides
             heading_style: title
             icon: mdi:book-open-page-variant
@@ -567,7 +635,7 @@ views:
     header:
       card:
         type: markdown
-        content: '### Home Battery Control *(v4.6.3)*'
+        content: '### Home Battery Control *(v4.7.0)*'
         text_only: true
     cards: []
   - type: sections
@@ -2058,6 +2126,136 @@ views:
           - condition: numeric_state
             entity: input_number.house_battery_count
             above: 3
+      - type: grid
+        cards:
+          - type: heading
+            icon: mdi:power-plug-battery
+            heading: Marstek M5
+            heading_style: title
+          - type: vertical-stack
+            cards:
+              - type: markdown
+                content: '**<font color="#9b9b9b">Discharging</font>**'
+                text_only: true
+              - type: tile
+                entity: input_number.marstek_m5_discharging_cutoff_capacity
+                name: Cutoff capacity
+                hide_state: true
+                vertical: false
+                features:
+                  - type: numeric-input
+                    style: buttons
+                features_position: inline
+              - type: tile
+                entity: number.marstek_m5_max_discharge_power
+                name: Max Power
+                hide_state: true
+                vertical: false
+                features:
+                  - type: numeric-input
+                    style: buttons
+                features_position: inline
+            grid_options:
+              columns: 12
+              rows: auto
+          - type: vertical-stack
+            cards:
+              - type: markdown
+                content: '**<font color="#9b9b9b">Charging</font>**'
+                text_only: true
+              - type: tile
+                grid_options:
+                  columns: 12
+                  rows: 2
+                entity: input_number.marstek_m5_charging_cutoff_capacity
+                name: Cutoff capacity
+                hide_state: true
+                vertical: false
+                features:
+                  - type: numeric-input
+                    style: buttons
+                features_position: inline
+              - type: tile
+                grid_options:
+                  columns: 12
+                  rows: 2
+                entity: number.marstek_m5_max_charge_power
+                name: 'Max. Power '
+                hide_state: true
+                vertical: false
+                features:
+                  - type: numeric-input
+                    style: buttons
+                features_position: inline
+        visibility:
+          - condition: numeric_state
+            entity: input_number.house_battery_count
+            above: 4
+      - type: grid
+        cards:
+          - type: heading
+            icon: mdi:power-plug-battery
+            heading: Marstek M6
+            heading_style: title
+          - type: vertical-stack
+            cards:
+              - type: markdown
+                content: '**<font color="#9b9b9b">Discharging</font>**'
+                text_only: true
+              - type: tile
+                entity: input_number.marstek_m6_discharging_cutoff_capacity
+                name: Cutoff capacity
+                hide_state: true
+                vertical: false
+                features:
+                  - type: numeric-input
+                    style: buttons
+                features_position: inline
+              - type: tile
+                entity: number.marstek_m6_max_discharge_power
+                name: Max Power
+                hide_state: true
+                vertical: false
+                features:
+                  - type: numeric-input
+                    style: buttons
+                features_position: inline
+            grid_options:
+              columns: 12
+              rows: auto
+          - type: vertical-stack
+            cards:
+              - type: markdown
+                content: '**<font color="#9b9b9b">Charging</font>**'
+                text_only: true
+              - type: tile
+                grid_options:
+                  columns: 12
+                  rows: 2
+                entity: input_number.marstek_m6_charging_cutoff_capacity
+                name: Cutoff capacity
+                hide_state: true
+                vertical: false
+                features:
+                  - type: numeric-input
+                    style: buttons
+                features_position: inline
+              - type: tile
+                grid_options:
+                  columns: 12
+                  rows: 2
+                entity: number.marstek_m6_max_charge_power
+                name: 'Max. Power '
+                hide_state: true
+                vertical: false
+                features:
+                  - type: numeric-input
+                    style: buttons
+                features_position: inline
+        visibility:
+          - condition: numeric_state
+            entity: input_number.house_battery_count
+            above: 5
     cards: []
     badges:
       - type: entity
@@ -2079,3 +2277,4 @@ views:
       layout: center
       badges_position: top
       badges_wrap: scroll
+  

--- a/home assistant/packages/house_battery_control.yaml
+++ b/home assistant/packages/house_battery_control.yaml
@@ -123,7 +123,7 @@ input_number:
     # Number of Marstek batteries
     name: "Number of batteries"
     min: 1
-    max: 4
+    max: 6
     step: 1
     unit_of_measurement: ""
     mode: slider
@@ -133,7 +133,7 @@ input_number:
   house_battery_control_prioritize_battery:
     name: "Prioritize battery"
     min: 1
-    max: 4
+    max: 6
     step: 1
     unit_of_measurement: ""
     mode: box
@@ -586,6 +586,44 @@ input_number:
     mode: box
     icon: mdi:battery-10
 
+  marstek_m5_charging_cutoff_capacity:
+    name: "Marstek M5 Charging Cutoff Capacity"
+    min: 80
+    max: 100
+    initial: 100
+    step: 1
+    unit_of_measurement: "%"
+    mode: box
+    icon: mdi:battery-90
+
+  marstek_m5_discharging_cutoff_capacity:
+    name: "Marstek M5 Discharging Cutoff Capacity"
+    min: 12
+    max: 80
+    step: 1
+    unit_of_measurement: "%"
+    mode: box
+    icon: mdi:battery-10
+
+  marstek_m6_charging_cutoff_capacity:
+    name: "Marstek M6 Charging Cutoff Capacity"
+    min: 80
+    max: 100
+    initial: 100
+    step: 1
+    unit_of_measurement: "%"
+    mode: box
+    icon: mdi:battery-90
+
+  marstek_m6_discharging_cutoff_capacity:
+    name: "Marstek M6 Discharging Cutoff Capacity"
+    min: 12
+    max: 80
+    step: 1
+    unit_of_measurement: "%"
+    mode: box
+    icon: mdi:battery-10
+
 ###########################################################################################################
 # INPUT_TEXT
 ###########################################################################################################
@@ -767,6 +805,8 @@ template:
             'sensor.marstek_m2_battery_power',
             'sensor.marstek_m3_battery_power', 
             'sensor.marstek_m4_battery_power',
+            'sensor.marstek_m5_battery_power',
+            'sensor.marstek_m6_battery_power',
           ] %}
           {{ expand(bat_entities) | selectattr('state', 'is_number') | list | length > 0 }}
         state: >
@@ -776,6 +816,8 @@ template:
             'sensor.marstek_m2_battery_power',
             'sensor.marstek_m3_battery_power', 
             'sensor.marstek_m4_battery_power',
+            'sensor.marstek_m5_battery_power',
+            'sensor.marstek_m6_battery_power',
           ] %}
 
           {# Filter entities on valid values and retrieve power #}

--- a/node-red/01 start-flow.json
+++ b/node-red/01 start-flow.json
@@ -2,7 +2,7 @@
     {
         "id": "8ec5147c0b5a7c62",
         "type": "tab",
-        "label": "Home Battery Start v4.6.3",
+        "label": "Home Battery Start v4.7.0",
         "disabled": false,
         "info": "# Home battery control\r\nConsists of three flows:\r\n 1.  Start flow\r\n 1.  Control flow\r\n 1.  Master switch flow\r\n\r\n## Start flow\r\nThis is the starting point of your home battery control.\r\n\r\nIt starts with P1 measurement as a trigger.\r\nIt allows you to connect your battery sensors to the flow.\r\nIt ends with a function node, mapping your batteries to a battery_array\r\n\r\nThe battery_array is passed on to the control flow.\r\n\r\nWhen the control flow has calculated the desired corrections,\r\nit is passed back to this flow and applied to your batteries.",
         "env": []

--- a/node-red/02 strategy-charge-pv.json
+++ b/node-red/02 strategy-charge-pv.json
@@ -2,7 +2,7 @@
     {
         "id": "f83cd63ed7d0d814",
         "type": "tab",
-        "label": "Strategy Charge PV v4.6.3",
+        "label": "Strategy Charge PV v4.7.0",
         "disabled": false,
         "info": "",
         "env": []

--- a/node-red/02 strategy-charge.json
+++ b/node-red/02 strategy-charge.json
@@ -2,7 +2,7 @@
     {
         "id": "c0b0803a0b7b5f6b",
         "type": "tab",
-        "label": "Strategy Charge v4.6.3",
+        "label": "Strategy Charge v4.7.0",
         "disabled": false,
         "info": "",
         "env": []

--- a/node-red/02 strategy-dynamic.json
+++ b/node-red/02 strategy-dynamic.json
@@ -2,7 +2,7 @@
     {
         "id": "99f6e455efa54b3a",
         "type": "tab",
-        "label": "Strategy Dynamic v4.6.3",
+        "label": "Strategy Dynamic v4.7.0",
         "disabled": false,
         "info": "Dynamic contract automated management",
         "env": []

--- a/node-red/02 strategy-full-stop.json
+++ b/node-red/02 strategy-full-stop.json
@@ -2,7 +2,7 @@
     {
         "id": "e2e92ce99c1547de",
         "type": "tab",
-        "label": "Strategy Full stop v4.6.3",
+        "label": "Strategy Full stop v4.7.0",
         "disabled": false,
         "info": "",
         "env": []

--- a/node-red/02 strategy-self-consumption.json
+++ b/node-red/02 strategy-self-consumption.json
@@ -2,7 +2,7 @@
     {
         "id": "736b000263ea5101",
         "type": "tab",
-        "label": "Strategy Self-consumption v4.6.3",
+        "label": "Strategy Self-consumption v4.7.0",
         "disabled": false,
         "info": "",
         "env": []

--- a/node-red/02 strategy-sell.json
+++ b/node-red/02 strategy-sell.json
@@ -2,7 +2,7 @@
     {
         "id": "c13c59039e2f8fa1",
         "type": "tab",
-        "label": "Strategy Sell v4.6.3",
+        "label": "Strategy Sell v4.7.0",
         "disabled": false,
         "info": "",
         "env": []

--- a/node-red/02 strategy-timed.json
+++ b/node-red/02 strategy-timed.json
@@ -2,7 +2,7 @@
     {
         "id": "7ad69230540da69c",
         "type": "tab",
-        "label": "Strategy Timed v4.6.3",
+        "label": "Strategy Timed v4.7.0",
         "disabled": false,
         "info": "",
         "env": []

--- a/node-red/all-flows-in-one-file.json
+++ b/node-red/all-flows-in-one-file.json
@@ -1,30 +1,6 @@
-[
+﻿[
     {
-        "id": "0a25621f3d1c985f",
-        "type": "tab",
-        "label": "Home Battery Test",
-        "disabled": false,
-        "info": "",
-        "env": []
-    },
-    {
-        "id": "68f2a63283f405e0",
-        "type": "tab",
-        "label": "Close-in optimize",
-        "disabled": false,
-        "info": "",
-        "env": []
-    },
-    {
-        "id": "a5fa1fcc1b306096",
-        "type": "tab",
-        "label": "HBC configuration UI",
-        "disabled": true,
-        "info": "",
-        "env": []
-    },
-    {
-        "id": "0175d4a664d6a895",
+        "id": "90ba722d19d180d0",
         "type": "tab",
         "label": "Home Battery Master Switch",
         "disabled": false,
@@ -32,7 +8,7 @@
         "env": []
     },
     {
-        "id": "372bd960bc6674b6",
+        "id": "3d30ac5470c32b57",
         "type": "tab",
         "label": "Home Battery PID presets",
         "disabled": false,
@@ -40,416 +16,83 @@
         "env": []
     },
     {
-        "id": "48ac861af1dcedb4",
+        "id": "23a4e27f08db4d94",
         "type": "tab",
-        "label": "Home Battery Start v4.6.3",
+        "label": "Home Battery Start v4.7.0",
         "disabled": false,
         "info": "# Home battery control\r\nConsists of three flows:\r\n 1.  Start flow\r\n 1.  Control flow\r\n 1.  Master switch flow\r\n\r\n## Start flow\r\nThis is the starting point of your home battery control.\r\n\r\nIt starts with P1 measurement as a trigger.\r\nIt allows you to connect your battery sensors to the flow.\r\nIt ends with a function node, mapping your batteries to a battery_array\r\n\r\nThe battery_array is passed on to the control flow.\r\n\r\nWhen the control flow has calculated the desired corrections,\r\nit is passed back to this flow and applied to your batteries.",
         "env": []
     },
     {
-        "id": "dfa0cbce6ff0c1a2",
+        "id": "889df07ac7f6b084",
         "type": "tab",
-        "label": "Strategy Charge PV v4.6.3",
+        "label": "Strategy Charge PV v4.7.0",
         "disabled": false,
         "info": "",
         "env": []
     },
     {
-        "id": "ea282c9a1916db76",
+        "id": "d60f98965bf0409c",
         "type": "tab",
-        "label": "Strategy Charge v4.6.3",
+        "label": "Strategy Charge v4.7.0",
         "disabled": false,
         "info": "",
         "env": []
     },
     {
-        "id": "99f6e455efa54b3a",
+        "id": "c11340415b97b938",
         "type": "tab",
-        "label": "Strategy Dynamic v4.6.3",
+        "label": "Strategy Dynamic v4.7.0",
         "disabled": false,
         "info": "Dynamic contract automated management",
         "env": []
     },
     {
-        "id": "85b49ff0f08a1d72",
+        "id": "01a80123db086eba",
         "type": "tab",
-        "label": "Strategy Full stop v4.6.3",
+        "label": "Strategy Full stop v4.7.0",
         "disabled": false,
         "info": "",
         "env": []
     },
     {
-        "id": "95b545927e70ace9",
+        "id": "1d3cf6be03a635b7",
         "type": "tab",
-        "label": "Strategy Self-consumption v4.6.3",
+        "label": "Strategy Self-consumption v4.7.0",
         "disabled": false,
         "info": "",
         "env": []
     },
     {
-        "id": "45268219e4d1f409",
+        "id": "8ba5b00d69c6f447",
         "type": "tab",
-        "label": "Strategy Sell v4.6.3",
+        "label": "Strategy Sell v4.7.0",
         "disabled": false,
         "info": "",
         "env": []
     },
     {
-        "id": "9e39224fc3ece381",
+        "id": "c09e6bbf3a0800ef",
         "type": "tab",
-        "label": "Strategy Timed v4.6.3",
+        "label": "Strategy Timed v4.7.0",
         "disabled": false,
         "info": "",
         "env": []
     },
     {
-        "id": "4776ad4f0339c6ae",
+        "id": "68c1ff5282e98cfc",
         "type": "group",
-        "z": "0a25621f3d1c985f",
-        "style": {
-            "stroke": "#999999",
-            "stroke-opacity": "1",
-            "fill": "none",
-            "fill-opacity": "1",
-            "label": true,
-            "label-position": "nw",
-            "color": "#a4a4a4"
-        },
-        "nodes": [
-            "7ec432c49bd7aad2",
-            "6c10fd50e5e23c5c",
-            "807fecff3dd1e9d7",
-            "c32afffb5ac57d79",
-            "5caaf9fa7ecd954b"
-        ],
-        "x": 54,
-        "y": 159,
-        "w": 692,
-        "h": 142
-    },
-    {
-        "id": "fe54093811b6a7fe",
-        "type": "group",
-        "z": "0a25621f3d1c985f",
-        "name": "Hit \"Do a test\" to perform a test",
-        "style": {
-            "label": true
-        },
-        "nodes": [
-            "ac7f5f881b0f026f",
-            "869beb2c2332637b",
-            "16e609e6f5bfaff8"
-        ],
-        "x": 54,
-        "y": 59,
-        "w": 732,
-        "h": 82
-    },
-    {
-        "id": "d94668c8ae9cf8a1",
-        "type": "group",
-        "z": "0a25621f3d1c985f",
-        "name": "Set state",
-        "style": {
-            "label": true
-        },
-        "nodes": [
-            "931cccdaaeafbd38",
-            "f0629b49c28c5864",
-            "5cfda233ce27dc73",
-            "f4e777264f65f640"
-        ],
-        "x": 54,
-        "y": 319,
-        "w": 412,
-        "h": 162
-    },
-    {
-        "id": "d6af2a36d0dfdda5",
-        "type": "group",
-        "z": "0a25621f3d1c985f",
-        "name": "Set power",
-        "style": {
-            "label": true
-        },
-        "nodes": [
-            "bc9e96111f996807",
-            "275647d6fa79f142",
-            "26629155a2d9c3ba",
-            "8cd5b26ec5d86f60"
-        ],
-        "x": 474,
-        "y": 319,
-        "w": 412,
-        "h": 162
-    },
-    {
-        "id": "937c3952d6bb2e19",
-        "type": "group",
-        "z": "a5fa1fcc1b306096",
-        "name": "Field types",
-        "style": {
-            "label": true
-        },
-        "nodes": [
-            "58d6c7b724b10666",
-            "e740f315724f3d1a",
-            "e60f983d4392917d",
-            "9d500a3c6b154999"
-        ],
-        "x": 494,
-        "y": 63,
-        "w": 172,
-        "h": 658,
-        "info": "Allow users to easily find the right sensors/selects/etc."
-    },
-    {
-        "id": "9873daf982c701e7",
-        "type": "group",
-        "z": "a5fa1fcc1b306096",
-        "name": "Test readout",
-        "style": {
-            "label": true
-        },
-        "nodes": [
-            "c04872de572310e0",
-            "f8b1b99ed5b34b59",
-            "7bc1318c6e070317",
-            "7a4b7e517f4cf506",
-            "c223121624220b75"
-        ],
-        "x": 194,
-        "y": 939,
-        "w": 812,
-        "h": 162
-    },
-    {
-        "id": "0d03e2a33f3a64b3",
-        "type": "group",
-        "z": "a5fa1fcc1b306096",
-        "name": "HA fields (read)",
-        "style": {
-            "label": true
-        },
-        "nodes": [
-            "64d24e6545b1f86f",
-            "3805ea99193c192c",
-            "79aede9e29152eb5",
-            "967320583833cbad",
-            "1cb5651fd3cd98f7",
-            "a71c7d4cd9e9ecb6",
-            "1a684759a42f72ef",
-            "c0114cdc7b15fba9",
-            "9a53b5725a7ae343",
-            "15d0a55aad6896dc",
-            "892e1829e04b12de",
-            "a0c32b752bed188a",
-            "521c90d39990183f",
-            "11b529145ce5d713",
-            "45e6ad9cded99ea2"
-        ],
-        "x": 684,
-        "y": 63,
-        "w": 104,
-        "h": 798
-    },
-    {
-        "id": "795071f84cc65671",
-        "type": "group",
-        "z": "a5fa1fcc1b306096",
-        "name": "NR dashboard ",
-        "style": {
-            "label": true
-        },
-        "nodes": [
-            "c659d02c18f850a9",
-            "028a4c9c51e7eccd",
-            "aa7fa18db5e480cc",
-            "7df02adfcd4128ea",
-            "a755b33f1730e891",
-            "14124387949b0fee",
-            "7867622927f0d077",
-            "ebb77d5a4bb73b23",
-            "b39feae3a058ace5",
-            "1f8079b3d993b6ff",
-            "3c2735a64344066e",
-            "77426ad1f331d3f8",
-            "af5a6883b065a9fc",
-            "4d3e69a2b3b4e1bd",
-            "8d2077410a644d6e"
-        ],
-        "x": 854,
-        "y": 63,
-        "w": 352,
-        "h": 798
-    },
-    {
-        "id": "e9025250f91b9eb0",
-        "type": "group",
-        "z": "a5fa1fcc1b306096",
-        "name": "Store NR into HA fields on change",
-        "style": {
-            "label": true
-        },
-        "nodes": [
-            "3323e8b0f6c0ee75",
-            "edf81a129949f7af",
-            "c2f36f14e0eb1058"
-        ],
-        "x": 1234,
-        "y": 59,
-        "w": 512,
-        "h": 266
-    },
-    {
-        "id": "23508a0784b7a764",
-        "type": "group",
-        "z": "0a25621f3d1c985f",
-        "name": "Battery setting looper",
-        "style": {
-            "label": true
-        },
-        "nodes": [
-            "952dcb76faf9377b",
-            "d37894c2b1e074da",
-            "e2c98a4a11d3119b",
-            "7d491da9cff1228d",
-            "ed583566b7d2e5a5",
-            "1de0ea92dde0cb92",
-            "32c18b304ab18eef",
-            "40b65d5d85625cf3",
-            "b6036af3515b400f",
-            "ef5d062ab8c5730b",
-            "317a70d47e45df87",
-            "544d7fe378e8f4f1",
-            "b1a0880f8fb62bf2",
-            "10e04cfa04d1fb5f",
-            "3cb20d31ca53816b"
-        ],
-        "x": 54,
-        "y": 499,
-        "w": 792,
-        "h": 342
-    },
-    {
-        "id": "99dab2f005d99056",
-        "type": "group",
-        "z": "0a25621f3d1c985f",
-        "name": "Generic action node",
-        "style": {
-            "label": true
-        },
-        "nodes": [
-            "721c6c9f8abb8939",
-            "85e53fe14fe8c336",
-            "53bdff08247dc43b"
-        ],
-        "x": 874,
-        "y": 499,
-        "w": 572,
-        "h": 82
-    },
-    {
-        "id": "137e6287c81f0267",
-        "type": "group",
-        "z": "0a25621f3d1c985f",
-        "name": "Battery reordering",
-        "style": {
-            "label": true
-        },
-        "nodes": [
-            "6b3e5f2f22e3df05",
-            "61aeb6b570e5d0f6",
-            "149a6d03c4420699"
-        ],
-        "x": 54,
-        "y": 859,
-        "w": 512,
-        "h": 82
-    },
-    {
-        "id": "a9c604eb640d5087",
-        "type": "group",
-        "z": "0a25621f3d1c985f",
-        "name": "Cheapest hour integration",
-        "style": {
-            "label": true
-        },
-        "nodes": [
-            "1b87bb9331aa7957",
-            "03999a11700893e1",
-            "06742153914f176c",
-            "77a60a41e79103b6",
-            "bc3b82ace59b9797",
-            "0ff3238209d01e07",
-            "b43975f0bd7d3bcc",
-            "1c53d1727770d10f",
-            "dd12fb024f91a46c",
-            "d21932c2d5c60e3c",
-            "6904fb44493109bc",
-            "a79347dc7b41ced3"
-        ],
-        "x": 54,
-        "y": 979,
-        "w": 1032,
-        "h": 222
-    },
-    {
-        "id": "66edb01751dea0f8",
-        "type": "group",
-        "z": "0a25621f3d1c985f",
-        "name": "Flow tracing",
-        "style": {
-            "label": true
-        },
-        "nodes": [
-            "71b212e67de97103",
-            "4cff99f65954edec",
-            "7cdff9e39aebf2c5",
-            "da820c91ddee7552",
-            "7e3a9ac873bdc028"
-        ],
-        "x": 874,
-        "y": 619,
-        "w": 592,
-        "h": 162
-    },
-    {
-        "id": "84df681959deba36",
-        "type": "group",
-        "z": "0a25621f3d1c985f",
-        "name": "Logging and thinking",
-        "style": {
-            "label": true
-        },
-        "nodes": [
-            "0a8e0cf84f3d5f42",
-            "fd2c1bd1c1bb9628",
-            "de74be27ad34f443",
-            "98879159d5e86be8",
-            "24d378c6060d0323",
-            "1ef6879cecdd47fe"
-        ],
-        "x": 874,
-        "y": 799,
-        "w": 632,
-        "h": 142
-    },
-    {
-        "id": "953fd66d6e9a5104",
-        "type": "group",
-        "z": "0175d4a664d6a895",
+        "z": "90ba722d19d180d0",
         "name": "Marstek master control switch",
         "style": {
             "label": true
         },
         "nodes": [
-            "00bc695e6e14ac68",
-            "3e234ef1ac1876ef",
-            "c29838d388949d73",
-            "8f09b2ae8c025fcd",
-            "850a4db192a92f5c"
+            "77e00747c15d33d8",
+            "cca00e713027d587",
+            "5a66d9b14e186590",
+            "364d5ef5318739ef",
+            "4c9715590340f74a"
         ],
         "x": 34,
         "y": 19,
@@ -457,21 +100,21 @@
         "h": 382
     },
     {
-        "id": "77e8d4e34d78e299",
+        "id": "6fd1d2a9a49cdcf4",
         "type": "group",
-        "z": "372bd960bc6674b6",
+        "z": "3d30ac5470c32b57",
         "name": "PID presets",
         "style": {
             "label": true
         },
         "nodes": [
-            "ab11a2efc339a986",
-            "55f9708f59d9a023",
-            "5920c11bd429721a",
-            "f47ec641a00398ae",
-            "2c085b75d84e29dd",
-            "37ddfce1de5fed7e",
-            "37faa6d3c80dc619"
+            "0a5681c3e62ca4ac",
+            "df1709d77a25c3be",
+            "efbb4e7edd2bbc0e",
+            "ec0d3dc0a6333191",
+            "60bdd7beed2695a3",
+            "d56baae3fc3002ca",
+            "e4758c2f74c708fb"
         ],
         "x": 34,
         "y": 19,
@@ -479,16 +122,16 @@
         "h": 242
     },
     {
-        "id": "72219ac095fb2ca7",
+        "id": "d12e7189dbb4a8c1",
         "type": "group",
-        "z": "dfa0cbce6ff0c1a2",
+        "z": "889df07ac7f6b084",
         "name": "Battery solutions",
         "style": {
             "label": true
         },
         "nodes": [
-            "94e7b2a834260f5e",
-            "181c689ab3b8d58b"
+            "3421fa0a5a803b53",
+            "e74410daf9280ceb"
         ],
         "x": 1184,
         "y": 59,
@@ -496,17 +139,17 @@
         "h": 142
     },
     {
-        "id": "6c719ad1b1b5d932",
+        "id": "a365917b24c83755",
         "type": "group",
-        "z": "dfa0cbce6ff0c1a2",
+        "z": "889df07ac7f6b084",
         "name": "Start",
         "style": {
             "label": true
         },
         "nodes": [
-            "e4eccc0b9ca0a9dc",
-            "ac182b81fae26bdb",
-            "51cfba29204ad7ff"
+            "af36a06160da45e1",
+            "64795d59800fc62f",
+            "e57e883f7be479bc"
         ],
         "x": 14,
         "y": 79,
@@ -514,9 +157,9 @@
         "h": 162
     },
     {
-        "id": "4de60a2978bb51c9",
+        "id": "55ecd7da708b2bd4",
         "type": "group",
-        "z": "dfa0cbce6ff0c1a2",
+        "z": "889df07ac7f6b084",
         "name": "Unhandled exceptions",
         "style": {
             "label": true,
@@ -524,9 +167,9 @@
             "color": "#d88a8a"
         },
         "nodes": [
-            "39d704a68513bd47",
-            "26fda02e6fa0fe69",
-            "dfa93e91042443de"
+            "4f8432f0d078b6ee",
+            "b4acc2524c25a0e8",
+            "40fd2cc4ce71f0ca"
         ],
         "x": 14,
         "y": 259,
@@ -534,9 +177,9 @@
         "h": 82
     },
     {
-        "id": "9567cf44eb70463d",
+        "id": "d9f0bc2a9b86a02c",
         "type": "group",
-        "z": "dfa0cbce6ff0c1a2",
+        "z": "889df07ac7f6b084",
         "style": {
             "stroke": "#565656",
             "stroke-opacity": "1",
@@ -547,8 +190,8 @@
             "color": "#cccccc"
         },
         "nodes": [
-            "920de7de0f4325f6",
-            "52a273930dbe024b"
+            "44dc3499d20d0627",
+            "a5a1152348357755"
         ],
         "x": 594,
         "y": 119,
@@ -556,9 +199,9 @@
         "h": 82
     },
     {
-        "id": "38bba18f3d579ec7",
+        "id": "f9bc47ded21ba4df",
         "type": "group",
-        "z": "dfa0cbce6ff0c1a2",
+        "z": "889df07ac7f6b084",
         "style": {
             "stroke": "#565656",
             "stroke-opacity": "1",
@@ -569,9 +212,9 @@
             "color": "#cccccc"
         },
         "nodes": [
-            "b3560dc235a3bf07",
-            "06b33ef774980631",
-            "ae35dc57dde4e6e6"
+            "ca4151ce7a16368c",
+            "f24d62ee3f778ac5",
+            "186720c4c21e4f7c"
         ],
         "x": 594,
         "y": 219,
@@ -579,16 +222,16 @@
         "h": 82
     },
     {
-        "id": "82fa2a7ed35302d9",
+        "id": "608fa319cec8ec48",
         "type": "group",
-        "z": "99f6e455efa54b3a",
+        "z": "c11340415b97b938",
         "name": "Battery solutions",
         "style": {
             "label": true
         },
         "nodes": [
-            "b4698212756bbf09",
-            "e7b989fd220fb54f"
+            "576355e6681c94a4",
+            "dc992ac885050b63"
         ],
         "x": 934,
         "y": 79,
@@ -596,17 +239,17 @@
         "h": 142
     },
     {
-        "id": "d3c9838fd79f66ff",
+        "id": "1e4d2d34b639b7f8",
         "type": "group",
-        "z": "99f6e455efa54b3a",
+        "z": "c11340415b97b938",
         "name": "Home battery start",
         "style": {
             "label": true
         },
         "nodes": [
-            "10b840d73039794e",
-            "de82e260dd892bd8",
-            "d90bac11be9193dd"
+            "02c9f5debe469ff7",
+            "2eab1c5e3e74ddea",
+            "11b8c0e6011b9efb"
         ],
         "x": 14,
         "y": 79,
@@ -614,21 +257,21 @@
         "h": 162
     },
     {
-        "id": "47b0e8e393df1fc5",
+        "id": "9f89ee41a453c9a9",
         "type": "group",
-        "z": "99f6e455efa54b3a",
+        "z": "c11340415b97b938",
         "name": "Plan",
         "style": {
             "label": true
         },
         "nodes": [
-            "581802933376d25f",
-            "00f349135fcb047d",
-            "11f4b7e2ce0e31cf",
-            "1a25a576362108df",
-            "101917fb25d567d6",
-            "1c58bd73aef4538b",
-            "b4d8861efefe4972"
+            "cac65cdd2a3d5080",
+            "0b12f31ff704ac06",
+            "e8f1c331e2327281",
+            "bb03acd17ff3399c",
+            "b974ba39dc7d0bca",
+            "8c1deab0e5e6f11a",
+            "b2852c433afeb8cc"
         ],
         "x": 228,
         "y": 273,
@@ -636,19 +279,19 @@
         "h": 1054
     },
     {
-        "id": "72b9126748df875e",
+        "id": "d145546c4cfb1e34",
         "type": "group",
-        "z": "99f6e455efa54b3a",
+        "z": "c11340415b97b938",
         "name": "Execute",
         "style": {
             "label": true
         },
         "nodes": [
-            "d1f365c57678f171",
-            "72dfc4f99ef6204b",
-            "3688acf38b3e7b48",
-            "e50e769f731f1a5c",
-            "26b26089165ee47f"
+            "e09e9cb63348d8ed",
+            "72965df35ce116d9",
+            "9fa38679952970f8",
+            "fa4df9d2aacebeab",
+            "0942c21d9a7aaefa"
         ],
         "x": 234,
         "y": 119,
@@ -656,22 +299,22 @@
         "h": 122
     },
     {
-        "id": "8738b26b32fee4e0",
+        "id": "2d3ed289b08737e5",
         "type": "group",
-        "z": "99f6e455efa54b3a",
+        "z": "c11340415b97b938",
         "name": "Test area",
         "style": {
             "label": true
         },
         "nodes": [
-            "8997d0a8d7413f77",
-            "b20a8cd75d1686bd",
-            "1e42511310237759",
-            "48c31efefebe1bd4",
-            "f3857f90af5bca4f",
-            "bc15733f1195e478",
-            "80d5e168f64fb057",
-            "9ef13a670cc957eb"
+            "482804fa0836772f",
+            "9091501a4d56f41c",
+            "6bf27a045a91b6e9",
+            "4bfde5abb555b87c",
+            "a5d382a0064f1008",
+            "cecb18338a342a0e",
+            "aa39b322023b6826",
+            "b793788cb3a23b5c"
         ],
         "x": 234,
         "y": 1479,
@@ -679,19 +322,19 @@
         "h": 162
     },
     {
-        "id": "f4d47a8395e2352b",
+        "id": "066f5b1fcc1b752c",
         "type": "group",
-        "z": "99f6e455efa54b3a",
+        "z": "c11340415b97b938",
         "name": "All data",
         "style": {
             "label": true
         },
         "nodes": [
-            "bc2762fc445314c0",
-            "e6cce059e172bc4f",
-            "749fc82a266798a1",
-            "ca1888369786df2c",
-            "3c738f8cc897b9c2"
+            "70ab5c095d9a04d6",
+            "a8e46e32a85d4101",
+            "40ce2759a2b947e0",
+            "8f3c1e64dd9cd8c1",
+            "f8fad8da4ec02e6d"
         ],
         "x": 234,
         "y": 1659,
@@ -699,9 +342,9 @@
         "h": 142
     },
     {
-        "id": "00ac5116c0a59044",
+        "id": "a5103e4dc49c5cff",
         "type": "group",
-        "z": "99f6e455efa54b3a",
+        "z": "c11340415b97b938",
         "name": "Unhandled exceptions",
         "style": {
             "label": true,
@@ -709,9 +352,9 @@
             "color": "#d88a8a"
         },
         "nodes": [
-            "7aa7aa85cef5da6f",
-            "ac8806a4ebf78a24",
-            "adbe314017b329a3"
+            "d02eb043d62a6c0f",
+            "1a7066daead2a07c",
+            "c2f9d4444566824a"
         ],
         "x": 24,
         "y": 279,
@@ -719,17 +362,17 @@
         "h": 82
     },
     {
-        "id": "15efb03647185f54",
+        "id": "afb3e9d3ea7099e5",
         "type": "group",
-        "z": "85b49ff0f08a1d72",
+        "z": "01a80123db086eba",
         "name": "Strategy start",
         "style": {
             "label": true
         },
         "nodes": [
-            "f16e3f6676acc3ca",
-            "4441cfcbecac8772",
-            "a01a3f848fb689d9"
+            "e579f66465fbe1a8",
+            "2c760025651125e3",
+            "9cf1e7d4768dd638"
         ],
         "x": 14,
         "y": 79,
@@ -737,16 +380,16 @@
         "h": 162
     },
     {
-        "id": "937d5910d3ca1fec",
+        "id": "c4f1a5d1926361b9",
         "type": "group",
-        "z": "85b49ff0f08a1d72",
+        "z": "01a80123db086eba",
         "name": "Battery solutions",
         "style": {
             "label": true
         },
         "nodes": [
-            "1a0c85af80f362a7",
-            "2cd3e5bbf2fb8408"
+            "8fbd1f5d09a2eb31",
+            "2b281594aea3b7d8"
         ],
         "x": 464,
         "y": 79,
@@ -754,9 +397,9 @@
         "h": 142
     },
     {
-        "id": "838ed99b2dcae219",
+        "id": "9462cd98831eae79",
         "type": "group",
-        "z": "85b49ff0f08a1d72",
+        "z": "01a80123db086eba",
         "name": "Unhandled exceptions",
         "style": {
             "label": true,
@@ -764,9 +407,9 @@
             "color": "#d88a8a"
         },
         "nodes": [
-            "6234bf4f764f5240",
-            "5ea6762a56cf8b30",
-            "7805470f1308113e"
+            "a65dfdd83f7ea229",
+            "72331d6edaf1531e",
+            "22b854a4f9f53277"
         ],
         "x": 14,
         "y": 259,
@@ -774,18 +417,18 @@
         "h": 82
     },
     {
-        "id": "e78001626bd9db2e",
+        "id": "a3b887bda9320879",
         "type": "group",
-        "z": "95b545927e70ace9",
+        "z": "1d3cf6be03a635b7",
         "name": "Strategy start",
         "style": {
             "fill": "#ffffff",
             "label": true
         },
         "nodes": [
-            "7429f835c9869a7a",
-            "b49be705a4e166ed",
-            "a529ac673bea2b3c"
+            "20b59df6a52ece70",
+            "f4f5c6c083da0d22",
+            "8d6a4b253818f114"
         ],
         "x": 54,
         "y": 79,
@@ -793,18 +436,18 @@
         "h": 162
     },
     {
-        "id": "13d8169172cbd977",
+        "id": "805ff27a624e0a7f",
         "type": "group",
-        "z": "95b545927e70ace9",
+        "z": "1d3cf6be03a635b7",
         "name": "Battery solutions",
         "style": {
             "label": true,
             "fill": "#ffffff"
         },
         "nodes": [
-            "db62188eeb09a5fe",
-            "7c60441a294b5a22",
-            "920bae464a1f958b"
+            "535f8ee333775a18",
+            "104d4c3148b8cd19",
+            "7512d630ea96b3e9"
         ],
         "x": 64,
         "y": 1139,
@@ -812,19 +455,19 @@
         "h": 142
     },
     {
-        "id": "12e46fccb5802c71",
+        "id": "38f99932aad11a50",
         "type": "group",
-        "z": "95b545927e70ace9",
+        "z": "1d3cf6be03a635b7",
         "name": "Bumpless operation",
         "style": {
             "label": true,
             "stroke": "#bfdbef"
         },
         "nodes": [
-            "fc9a79906d48681f",
-            "71f8f0471c914c25",
-            "eda60b6eb688e118",
-            "83b75b812fff9770"
+            "2a26a1de36f05234",
+            "26098bfe361cba5b",
+            "05670e160fd72c4d",
+            "684f48ed70c30401"
         ],
         "x": 1614,
         "y": 19,
@@ -832,27 +475,27 @@
         "h": 242
     },
     {
-        "id": "0b266d0d6a782396",
+        "id": "3ed2a38d76be9667",
         "type": "group",
-        "z": "95b545927e70ace9",
+        "z": "1d3cf6be03a635b7",
         "name": "Bumpless operation - switching control modes",
         "style": {
             "stroke": "#bfdbef",
             "label": true
         },
         "nodes": [
-            "2a17f575ab4edb9a",
-            "229a18de6fecdbdf",
-            "283ec6ca6ed7d7c3",
-            "798c57f1fbed218f",
-            "328a1037fb53a26b",
-            "518ee919cd3efac1",
-            "5bf6859a2eb3736e",
-            "101ce775aa237ed9",
-            "80d79876154eca1b",
-            "ce067d9bbd24b919",
-            "5b2021e7f5061d68",
-            "478c3ce913f5e339"
+            "0b50278f356f3282",
+            "dd49186b76d0ee0d",
+            "7cc3ff28dc56daba",
+            "484f1bf00afa7c93",
+            "fa5b3eb85366eb75",
+            "7fac9748dd62b6bd",
+            "2373084a62c2feaa",
+            "da671bc3ae62f046",
+            "7735be058403fdf1",
+            "09456f5a8948bd0e",
+            "11841edbd6eb50aa",
+            "cc3e4dc8fecd193a"
         ],
         "x": 1614,
         "y": 279,
@@ -860,9 +503,9 @@
         "h": 289.5
     },
     {
-        "id": "8ff21e1d960e953f",
+        "id": "11ce1c9c6dabf691",
         "type": "group",
-        "z": "95b545927e70ace9",
+        "z": "1d3cf6be03a635b7",
         "name": "Inputs",
         "style": {
             "fill": "#7fb7df",
@@ -870,8 +513,8 @@
             "color": "#ffffff"
         },
         "nodes": [
-            "edc2a2a28871c43a",
-            "fbc01f9edcc6842a"
+            "0a55432a91ac4ec8",
+            "ad8b5d8b3606c48b"
         ],
         "x": 288,
         "y": 13,
@@ -879,9 +522,9 @@
         "h": 234
     },
     {
-        "id": "af6088abf152ca24",
+        "id": "6c638ca874330d9b",
         "type": "group",
-        "z": "95b545927e70ace9",
+        "z": "1d3cf6be03a635b7",
         "name": "Pre processing",
         "style": {
             "fill": "#bfdbef",
@@ -889,9 +532,9 @@
             "color": "#ffffff"
         },
         "nodes": [
-            "d893e2f37a24c25c",
-            "75642cb0b65d0e1e",
-            "d8c94b15828961e5"
+            "9a620a2a2f96288f",
+            "d9ae5f41bc83da9b",
+            "502610763c97d762"
         ],
         "x": 288,
         "y": 273,
@@ -899,9 +542,9 @@
         "h": 294
     },
     {
-        "id": "c5326024bff42548",
+        "id": "eaca266ff7533044",
         "type": "group",
-        "z": "95b545927e70ace9",
+        "z": "1d3cf6be03a635b7",
         "name": "Control",
         "style": {
             "fill": "#7fb7df",
@@ -909,8 +552,8 @@
             "color": "#ffffff"
         },
         "nodes": [
-            "6697a3fa1010723e",
-            "6d773e100cbddf8f"
+            "29995cd0b0073ccd",
+            "c0422f307e2b7a3f"
         ],
         "x": 288,
         "y": 593,
@@ -918,9 +561,9 @@
         "h": 634
     },
     {
-        "id": "37009bd6e266d3b6",
+        "id": "78c50df35fe0a532",
         "type": "group",
-        "z": "95b545927e70ace9",
+        "z": "1d3cf6be03a635b7",
         "name": "Unhandled exceptions",
         "style": {
             "label": true,
@@ -928,9 +571,9 @@
             "color": "#d88a8a"
         },
         "nodes": [
-            "28404ee9bffbd9bc",
-            "b7696ce52882d505",
-            "62f0daf706ea8d51"
+            "e53efde4b8bb20c7",
+            "f5fe682fec29feb2",
+            "b50ed0719809245a"
         ],
         "x": 54,
         "y": 279,
@@ -938,17 +581,17 @@
         "h": 82
     },
     {
-        "id": "246292447922fcbb",
+        "id": "86d607ed8d206722",
         "type": "group",
-        "z": "45268219e4d1f409",
+        "z": "8ba5b00d69c6f447",
         "name": "Configuration",
         "style": {
             "label": true
         },
         "nodes": [
-            "1cf0ee59d698937c",
-            "c317e60b806e44b0",
-            "5e424902e2b3c300"
+            "6fa309f87b9a4311",
+            "9fa4c0553e3fc69a",
+            "335427d0817d394d"
         ],
         "x": 34,
         "y": 99,
@@ -956,17 +599,17 @@
         "h": 162
     },
     {
-        "id": "dbe25a81c3549f8b",
+        "id": "eacc42e8c2f36428",
         "type": "group",
-        "z": "45268219e4d1f409",
+        "z": "8ba5b00d69c6f447",
         "name": "Battery solutions",
         "style": {
             "label": true
         },
         "nodes": [
-            "8db52fa86b32845f",
-            "62829e16a92f21a6",
-            "a3f14b65313acd42"
+            "1ec47dcaecbc9934",
+            "57dd0a20ace29b6b",
+            "5ce8150b15e8bbbc"
         ],
         "x": 34,
         "y": 479,
@@ -974,9 +617,9 @@
         "h": 142
     },
     {
-        "id": "7880ef0bdff4a97b",
+        "id": "e72106615ec789d4",
         "type": "group",
-        "z": "45268219e4d1f409",
+        "z": "8ba5b00d69c6f447",
         "name": "Export routine",
         "style": {
             "fill-opacity": "0.5",
@@ -984,14 +627,14 @@
             "color": "#cccccc"
         },
         "nodes": [
-            "732e7c368fd91726",
-            "3dfb017412210c2d",
-            "2cf3625539d84467",
-            "1ee027a08b5fa2ca",
-            "a878122484b8ade7",
-            "4cd4fdfca279a3ad",
-            "61a4d662deab1f8e",
-            "f358858eef8a40ea"
+            "bdf742552095efcb",
+            "1c6ee7deb5930ade",
+            "c484ab904b03e8f0",
+            "8016ca83d9ca33e9",
+            "e1e571717b44f101",
+            "3bfede3f1b8890f9",
+            "a07d0579bf039375",
+            "601999b6eb8e6113"
         ],
         "x": 254,
         "y": 319,
@@ -999,33 +642,33 @@
         "h": 182
     },
     {
-        "id": "a1f61dc615ba5d8f",
+        "id": "733019b51f77eb7a",
         "type": "group",
-        "z": "45268219e4d1f409",
+        "z": "8ba5b00d69c6f447",
         "name": "Decide export or stop",
         "style": {
             "label": true
         },
         "nodes": [
-            "6f306c9f5741cf4e",
-            "c03ff041a7142ecc",
-            "5023e4d6837ee277",
-            "af6f8e11181935f2",
-            "1ee914269e547271",
-            "382fbf05d750f570",
-            "3070b4f04d1ed836",
-            "65e116498f8e91d3",
-            "52c517eb55b55519",
-            "295e494c53b201d0",
-            "ec4416c541f0297e",
-            "19e2deec0b59aa3e",
-            "a7f5468f86d710bf",
-            "9d0bdc7bd80b7a2d",
-            "e6908f227e388e39",
-            "bb7a0784d0b0a22a",
-            "3d15c40d7d9c95f6",
-            "3b7e225dc182bb5c",
-            "1f2beb406508348d"
+            "e04893db342263e4",
+            "b5cd36a90cfbcefc",
+            "8f65bdecdb4a4288",
+            "10140a54c1c40f58",
+            "6f84c1c2f39b51b5",
+            "6e5acf1cfdd583e2",
+            "35c180cc2e111f20",
+            "2687dba26a756923",
+            "ee81b51972aa3e07",
+            "13900436861254c3",
+            "f5bd674e556d61fe",
+            "3d7f072c3ab91050",
+            "5e1748777184ab13",
+            "316260d4707381d4",
+            "6548cfcf77f80efe",
+            "3ecade755b21b53d",
+            "dab6d5b8acc929b6",
+            "3d7a88cb39de079b",
+            "c1a0dc6672015b4e"
         ],
         "x": 254,
         "y": 79,
@@ -1033,9 +676,9 @@
         "h": 207
     },
     {
-        "id": "e95797c2440b0faa",
+        "id": "8a2cca347fcb8d09",
         "type": "group",
-        "z": "45268219e4d1f409",
+        "z": "8ba5b00d69c6f447",
         "name": "Unhandled exceptions",
         "style": {
             "label": true,
@@ -1043,9 +686,9 @@
             "color": "#d88a8a"
         },
         "nodes": [
-            "5be717f63dea6b25",
-            "1eb7fb4ce8ab4110",
-            "dd2e5bf97c7876cd"
+            "529e71f22646a27b",
+            "10d4a7728ee7c964",
+            "09cff1fc2fd9ee36"
         ],
         "x": 34,
         "y": 379,
@@ -1053,16 +696,16 @@
         "h": 82
     },
     {
-        "id": "f63e605c588a8b4a",
+        "id": "5f88f837af19f280",
         "type": "group",
-        "z": "9e39224fc3ece381",
+        "z": "c09e6bbf3a0800ef",
         "name": "Battery solutions",
         "style": {
             "label": true
         },
         "nodes": [
-            "ce6d45b3bce03cef",
-            "d39fd4ac49ce6de3"
+            "9d6516c7832ce16d",
+            "af8877f380061516"
         ],
         "x": 1214,
         "y": 419,
@@ -1070,9 +713,9 @@
         "h": 142
     },
     {
-        "id": "f638c541e43f0f69",
+        "id": "abcad92e2e6ee7b8",
         "type": "group",
-        "z": "9e39224fc3ece381",
+        "z": "c09e6bbf3a0800ef",
         "style": {
             "stroke": "#565656",
             "stroke-opacity": "1",
@@ -1083,9 +726,9 @@
             "color": "#cccccc"
         },
         "nodes": [
-            "31775b862ba37b46",
-            "21e41b1aa944c3d4",
-            "722fe0c2ad88122e"
+            "1dceb39476cd10f2",
+            "79e577f3b7aac2ef",
+            "a1eb9a3022f44c9c"
         ],
         "x": 24,
         "y": 79,
@@ -1093,9 +736,9 @@
         "h": 162
     },
     {
-        "id": "76cf7d7bb3702120",
+        "id": "a5176edf2bc15719",
         "type": "group",
-        "z": "9e39224fc3ece381",
+        "z": "c09e6bbf3a0800ef",
         "style": {
             "stroke": "#565656",
             "stroke-opacity": "1",
@@ -1106,9 +749,9 @@
             "color": "#cccccc"
         },
         "nodes": [
-            "5dba707199b28c91",
-            "ee9bc4527bad8a05",
-            "5f99c3b39c65f674"
+            "560b4a9a1e8b91b9",
+            "e31d349eb20308ef",
+            "17827d992ed7afe4"
         ],
         "x": 454,
         "y": 79,
@@ -1116,9 +759,9 @@
         "h": 82
     },
     {
-        "id": "eb9d3a40ae2013dd",
+        "id": "8e537d3294b55627",
         "type": "group",
-        "z": "9e39224fc3ece381",
+        "z": "c09e6bbf3a0800ef",
         "style": {
             "stroke": "#565656",
             "stroke-opacity": "1",
@@ -1129,10 +772,10 @@
             "color": "#cccccc"
         },
         "nodes": [
-            "50623a53fc482b6d",
-            "4f863af7dfb788b7",
-            "f62cf74381b252b5",
-            "ac0e4f19465cfc6f"
+            "8f0d728b0caa0f19",
+            "1695c2c95a6e9097",
+            "b0172dad79c9d9d9",
+            "23f9975e55c16d6a"
         ],
         "x": 254,
         "y": 179,
@@ -1140,9 +783,9 @@
         "h": 82
     },
     {
-        "id": "faa98cae0df8f0ad",
+        "id": "376da246fd8c5004",
         "type": "group",
-        "z": "9e39224fc3ece381",
+        "z": "c09e6bbf3a0800ef",
         "style": {
             "stroke": "#565656",
             "stroke-opacity": "1",
@@ -1153,7 +796,7 @@
             "color": "#cccccc"
         },
         "nodes": [
-            "1c93b6485d540087"
+            "d2de59203f47d4c6"
         ],
         "x": 254,
         "y": 79,
@@ -1161,35 +804,35 @@
         "h": 82
     },
     {
-        "id": "bdf4f6805cf509e0",
+        "id": "585d1a52b35dfa92",
         "type": "group",
-        "z": "9e39224fc3ece381",
+        "z": "c09e6bbf3a0800ef",
         "name": "Determine sub-strategy based on time period",
         "style": {
             "label": true
         },
         "nodes": [
-            "6ebc6dcd578d07a2",
-            "b8fda06d12873ad8",
-            "5d43b1088113a139",
-            "f30fcd3659ee7c20",
-            "21f66951028bc3e3",
-            "f3a9a2ab8e3ab017",
-            "ac9f52c876b781d1",
-            "8f8a2d85bcf501bf",
-            "f186013b043694b7",
-            "8861cb91879fcbd7",
-            "49cecfb0dc7b9b56",
-            "66536c91bfd8a1f5",
-            "b090157c45157616",
-            "5dbf89cce4010125",
-            "c3fd307b8271989b",
-            "617af82ac31cf020",
-            "d8e50e39d010a883",
-            "3d49961ac821220e",
-            "1d78d845ee5ea7dd",
-            "f4640b7dc4624dc0",
-            "2afcd77cf7146900"
+            "76e9feedad68bca7",
+            "a4d0333032e37b8a",
+            "304a41111aa90bd6",
+            "b5d09f0f33171291",
+            "148b533a6ee8d566",
+            "1e5aedafc9c49701",
+            "f304ab42d3e05e83",
+            "6dfb0f680ff0cfe1",
+            "cb3cbbdc3470774d",
+            "f1e61865b1bd941b",
+            "cf31b793475b2611",
+            "8525462b2dad264e",
+            "89593c2befd0636d",
+            "8dd679613f4a188a",
+            "05d201d74c13fab1",
+            "07d1980ba5b9756d",
+            "c241c66d92808042",
+            "dbb15ac56eac7dd5",
+            "60f6b679d99d0d9f",
+            "54b7ea24d85ba059",
+            "bae4b34ea1057b55"
         ],
         "x": 254,
         "y": 379,
@@ -1197,16 +840,16 @@
         "h": 402
     },
     {
-        "id": "d19e5ec6b8c9a4d5",
+        "id": "5b8e1b80e73b4fc8",
         "type": "group",
-        "z": "9e39224fc3ece381",
+        "z": "c09e6bbf3a0800ef",
         "name": "Execute sub-strategy",
         "style": {
             "label": true
         },
         "nodes": [
-            "d814459ac074e134",
-            "88c9e4aef0a3943e"
+            "e9bd13a3fe069246",
+            "89cab6d8692ea12d"
         ],
         "x": 984,
         "y": 419,
@@ -1214,9 +857,9 @@
         "h": 142
     },
     {
-        "id": "6c47c0a8eb698b4d",
+        "id": "93bc9508e5ce3a86",
         "type": "group",
-        "z": "9e39224fc3ece381",
+        "z": "c09e6bbf3a0800ef",
         "style": {
             "stroke": "#565656",
             "stroke-opacity": "1",
@@ -1227,10 +870,10 @@
             "color": "#cccccc"
         },
         "nodes": [
-            "8278c04dbb97c853",
-            "5765d286d3f60ed6",
-            "552135bb95d425ef",
-            "0af565b205e2a70a"
+            "c2e1c79a0bc998ac",
+            "1e2448d228add1e8",
+            "d94002834ee44a50",
+            "72debbc7da5632d8"
         ],
         "x": 254,
         "y": 279,
@@ -1238,9 +881,9 @@
         "h": 82
     },
     {
-        "id": "811b50295a18f19b",
+        "id": "cd2f5d10eb8a15b5",
         "type": "group",
-        "z": "9e39224fc3ece381",
+        "z": "c09e6bbf3a0800ef",
         "name": "Unhandled exceptions",
         "style": {
             "label": true,
@@ -1248,9 +891,9 @@
             "color": "#d88a8a"
         },
         "nodes": [
-            "bc7a4236b52f0c97",
-            "ad82d7e9af9edabd",
-            "999c90deaf101f4c"
+            "1631387d18e1c2c0",
+            "d30b9008dd94d727",
+            "8ab1c24939e9c7d6"
         ],
         "x": 24,
         "y": 279,
@@ -1258,18 +901,18 @@
         "h": 82
     },
     {
-        "id": "b3bb650844db8d91",
+        "id": "1c746e23f2ce2ca7",
         "type": "group",
-        "z": "48ac861af1dcedb4",
+        "z": "23a4e27f08db4d94",
         "name": "Start",
         "style": {
             "label": true,
             "stroke": "#009ac7"
         },
         "nodes": [
-            "f8c504d6de9e8838",
-            "1535bb0687ee8cf4",
-            "b3d7ff14ccf5bde0"
+            "4c318cf475da639a",
+            "6523d6dc4284f77b",
+            "5a4559ef501fad73"
         ],
         "x": 34,
         "y": 19,
@@ -1277,22 +920,22 @@
         "h": 82
     },
     {
-        "id": "9b07562053189234",
+        "id": "d0359c3b08e2f524",
         "type": "group",
-        "z": "48ac861af1dcedb4",
+        "z": "23a4e27f08db4d94",
         "name": "Strategy selection",
         "style": {
             "label": true
         },
         "nodes": [
-            "654b3d36a54e6150",
-            "7c0c97a87c235885",
-            "3fbac4f34c6d43a5",
-            "e34805b6dc851f1c",
-            "a4c887d6a2ce98ec",
-            "4177e91aeda624f2",
-            "7f4cde90bcfe3341",
-            "70b289b6c85fb342"
+            "b47e86acdadefdf0",
+            "04ab02f28044ef0c",
+            "adb89d0bfdd1a012",
+            "a24f03a0b601c08e",
+            "925e44f5181079a0",
+            "c48cbfe9a99734a4",
+            "94442a5285ccfe38",
+            "a4839c4b9f153153"
         ],
         "x": 34,
         "y": 1099,
@@ -1300,22 +943,22 @@
         "h": 162
     },
     {
-        "id": "0f9a11f670a00bdc",
+        "id": "7f93f37162d70288",
         "type": "group",
-        "z": "48ac861af1dcedb4",
+        "z": "23a4e27f08db4d94",
         "name": "Get batteries information",
         "style": {
             "label": true
         },
         "nodes": [
-            "4dc4fb8c3e5a1669",
-            "8bed63ea4d3de2fe",
-            "60023d2aa6559b4b",
-            "d275a0ab915f2347",
-            "8b2ee74f2a91f366",
-            "4917f809fff8eecb",
-            "424e850ceb19ae8f",
-            "98c9fb279c1085b0"
+            "adc3e37b03aa3340",
+            "a7d69f37a6f47ec6",
+            "2a015f3c92bfdd5d",
+            "99acf563ae5fd9cc",
+            "240a191aa7efc2c6",
+            "f37e720c2c2dd4bd",
+            "ba8167f993127056",
+            "0e13f180d79e0a7f"
         ],
         "x": 34,
         "y": 379,
@@ -1323,18 +966,18 @@
         "h": 242
     },
     {
-        "id": "dbf744b373cca359",
+        "id": "9e68177ca9323103",
         "type": "group",
-        "z": "48ac861af1dcedb4",
+        "z": "23a4e27f08db4d94",
         "name": "On deploy and global logger",
         "style": {
             "label": true,
             "stroke": "#92d04f"
         },
         "nodes": [
-            "e291af9808f2c0ec",
-            "3f804e7d69164e0f",
-            "d0d3c9732bef1bda"
+            "dabd641f02dd7bed",
+            "8e80a92204bb72af",
+            "788ccdab960fea67"
         ],
         "x": 1294,
         "y": 19,
@@ -1342,21 +985,21 @@
         "h": 82
     },
     {
-        "id": "f76d0a5b93c10ffb",
+        "id": "eefa9cb839c2d5b2",
         "type": "group",
-        "z": "48ac861af1dcedb4",
+        "z": "23a4e27f08db4d94",
         "name": "Set Batteries",
         "style": {
             "label": true
         },
         "nodes": [
-            "d6476ede2bd72be0",
-            "499d4517ba5bcf18",
-            "69873d54a2788a83",
-            "cadf8c33c17cef4a",
-            "921b326acc2bb0ab",
-            "2e7fbbb3b27d2433",
-            "68bd6633d672835a"
+            "eed5d9618a14368c",
+            "17dd2482cb99b862",
+            "6c6f92bd8ea7eb6d",
+            "0f5639b779d2555c",
+            "2360ad1424ef4c48",
+            "19484ad2b48e8585",
+            "3d83f0a10274e5dd"
         ],
         "x": 34,
         "y": 1279,
@@ -1364,23 +1007,23 @@
         "h": 342
     },
     {
-        "id": "937b9038505ee9cb",
+        "id": "deaa42a10caeb85b",
         "type": "group",
-        "z": "48ac861af1dcedb4",
+        "z": "23a4e27f08db4d94",
         "name": "Battery priority",
         "style": {
             "label": true
         },
         "nodes": [
-            "93e4d6c51c83c9ae",
-            "0d693a1ee0231916",
-            "1076abf1997d083f",
-            "db89198b1ca39de8",
-            "b3864d7a5371ab7a",
-            "ad4b688ddaf97afc",
-            "ed62a7fca13e0a8b",
-            "6b4d2555302ec384",
-            "8ab1721d5fd454ce"
+            "8e76bcf8b496fbd9",
+            "814fda6266660353",
+            "804a344f635cb373",
+            "dca42b25d6b013e3",
+            "fac3effa820212e9",
+            "103d99e7fac0b8fa",
+            "cc591d3541af3f68",
+            "9b187fcddad353b9",
+            "b749a0c365b88ab0"
         ],
         "x": 34,
         "y": 899,
@@ -1388,15 +1031,15 @@
         "h": 82
     },
     {
-        "id": "ef23da74434d55e4",
+        "id": "200775166ba1a27b",
         "type": "group",
-        "z": "48ac861af1dcedb4",
+        "z": "23a4e27f08db4d94",
         "name": "Calculate totals",
         "style": {
             "label": true
         },
         "nodes": [
-            "8e95e6fefa2012d8"
+            "71664a6ed9350cc4"
         ],
         "x": 34,
         "y": 639,
@@ -1404,24 +1047,24 @@
         "h": 82
     },
     {
-        "id": "0d316b1cf81f65b1",
+        "id": "149350c2395c5836",
         "type": "group",
-        "z": "48ac861af1dcedb4",
+        "z": "23a4e27f08db4d94",
         "name": "Rate limiter",
         "style": {
             "label": true
         },
         "nodes": [
-            "8d8f01b0bddf8eb5",
-            "dec4611b05fb5eed",
-            "70acaaa579c0a018",
-            "89ba4d5f72b21b76",
-            "81672b5662a971ac",
-            "f4e32c63a96c3fa8",
-            "52d1f3da35515e31",
-            "bf7835ad1be027e8",
-            "19ddc55e9b42a045",
-            "103b546ad9e1d00e"
+            "e42a77152ac7634f",
+            "b65f73ccee8a2637",
+            "57bbefb5c23f0fc4",
+            "a9896eeb1ac753d3",
+            "caddfac7e1a76c06",
+            "182d1ff7fbffc581",
+            "51d579827f73db87",
+            "9ca8e9d6fa4dca81",
+            "8306f2a8e81443f8",
+            "abc4f73f1f878035"
         ],
         "x": 34,
         "y": 219,
@@ -1429,21 +1072,21 @@
         "h": 122
     },
     {
-        "id": "3c9ce920dfcd2460",
+        "id": "9ecdfccab179a392",
         "type": "group",
-        "z": "48ac861af1dcedb4",
+        "z": "23a4e27f08db4d94",
         "name": "Update UI: debug dashboard",
         "style": {
             "label": true,
             "stroke": "#3f5787"
         },
         "nodes": [
-            "abf9c4cf036aa0e8",
-            "912e47b9312875f1",
-            "23f62d92e226dfaf",
-            "2e959ec089b8532d",
-            "c0aa8ebae2966431",
-            "4376ef9c525c603a"
+            "e711da3f1e47c6df",
+            "4d69d6e21168fa27",
+            "f1d65a7781683032",
+            "d859b7c6ac97aa9f",
+            "966c3872c694eadd",
+            "56d0b7562c7c206f"
         ],
         "x": 1234,
         "y": 1479,
@@ -1451,25 +1094,25 @@
         "h": 202
     },
     {
-        "id": "a6ef66efd42a9f79",
+        "id": "8147fe89476d8165",
         "type": "group",
-        "z": "48ac861af1dcedb4",
+        "z": "23a4e27f08db4d94",
         "name": "Update UI: cummulative totals",
         "style": {
             "label": true,
             "stroke": "#3f5787"
         },
         "nodes": [
-            "e37a0ee09b1186d1",
-            "860e283819486c58",
-            "c7de808391c56099",
-            "7f3b18cc643a32d9",
-            "9d453126a447f823",
-            "0f1f729af948b051",
-            "d7b73d46113bf2da",
-            "bc76c00ced8129a4",
-            "c4a33dedf4f3e995",
-            "674f8659fbde7882"
+            "a2fc19c1d5226f60",
+            "616b4e11c9cd9b86",
+            "4a62d45425318b8f",
+            "0410669c44f8818b",
+            "c62651c153461a9b",
+            "cad158ddd473ae44",
+            "ea0955393fdf3a5a",
+            "ef996e3d84be8ca5",
+            "5e91d1e843b5bf9c",
+            "3f1d98c67242cdd8"
         ],
         "x": 1474,
         "y": 639,
@@ -1477,18 +1120,18 @@
         "h": 242
     },
     {
-        "id": "061960f18498b1de",
+        "id": "6434c6187d2b1dcc",
         "type": "group",
-        "z": "48ac861af1dcedb4",
+        "z": "23a4e27f08db4d94",
         "name": "Update UI: active sub-strategy",
         "style": {
             "label": true,
             "stroke": "#3f5787"
         },
         "nodes": [
-            "85a54c063f523e6a",
-            "55a4b32873e6e385",
-            "52d50e57e542972f"
+            "b26d8aadca1748b5",
+            "a571f72edce4f9b7",
+            "20dddde2b06aae74"
         ],
         "x": 1254,
         "y": 1179,
@@ -1496,20 +1139,20 @@
         "h": 82
     },
     {
-        "id": "829c23ac2351a872",
+        "id": "c9cd464ac5e9dea8",
         "type": "group",
-        "z": "48ac861af1dcedb4",
+        "z": "23a4e27f08db4d94",
         "name": "Insight",
         "style": {
             "label": true
         },
         "nodes": [
-            "c5a35a3e13c3974a",
-            "62b3339349fc6e88",
-            "09206d9eaa5cd7a8",
-            "2cbf3380b1b0897d",
-            "120283b1e9cd1293",
-            "8943b2424b61435b"
+            "622625722f27fd1d",
+            "f40438b466155cb5",
+            "d902acd1ee5701c2",
+            "a916cb28cbb336ed",
+            "4073f070084bd785",
+            "02b5708478962713"
         ],
         "x": 34,
         "y": 119,
@@ -1517,17 +1160,17 @@
         "h": 82
     },
     {
-        "id": "05453bf97681f245",
+        "id": "693e9f2c3d7c4bdc",
         "type": "group",
-        "z": "48ac861af1dcedb4",
+        "z": "23a4e27f08db4d94",
         "name": "Log and Error handling",
         "style": {
             "stroke": "#ff3f3f",
             "label": true
         },
         "nodes": [
-            "e2d0cf89de91a73a",
-            "c68009c541635661"
+            "21b7a17301542f47",
+            "b7d4d52c1c2d4a54"
         ],
         "x": 1634,
         "y": 119,
@@ -1535,9 +1178,9 @@
         "h": 142
     },
     {
-        "id": "36ac396eb898f9cb",
+        "id": "bc51ddc07489d498",
         "type": "group",
-        "z": "48ac861af1dcedb4",
+        "z": "23a4e27f08db4d94",
         "name": "Unhandled exceptions",
         "style": {
             "label": true,
@@ -1545,9 +1188,9 @@
             "color": "#d88a8a"
         },
         "nodes": [
-            "727b1940f24a4335",
-            "ed0ba936a7a42a23",
-            "2f3213f3bb3c7592"
+            "b97527322a2e7dbe",
+            "18d96a7db7840abf",
+            "c9416ef63c9c3561"
         ],
         "x": 1704,
         "y": 279,
@@ -1555,18 +1198,18 @@
         "h": 82
     },
     {
-        "id": "d32f52f0d1f5bc4f",
+        "id": "d4fc23990dd3a978",
         "type": "group",
-        "z": "48ac861af1dcedb4",
+        "z": "23a4e27f08db4d94",
         "name": "Peak shave settings",
         "style": {
             "label": true
         },
         "nodes": [
-            "f9c760a42193f376",
-            "19ce9d0a9bcbc0ec",
-            "e37fbe205de7ccff",
-            "06f11f240d034ca7"
+            "84caed3865b80c14",
+            "2f93e9d78bb9007c",
+            "9868d6db22856771",
+            "18ccc5431a016c01"
         ],
         "x": 34,
         "y": 999,
@@ -1574,17 +1217,17 @@
         "h": 82
     },
     {
-        "id": "e83ca9894fafba83",
+        "id": "3b30db19a6d0a9b0",
         "type": "group",
-        "z": "ea282c9a1916db76",
+        "z": "d60f98965bf0409c",
         "name": "Configuration",
         "style": {
             "label": true
         },
         "nodes": [
-            "b3b3227d475762d3",
-            "193129d79e10395b",
-            "60609e6c410aadc2"
+            "ba76c6477e7a8718",
+            "2b775c4b3fc7a4d6",
+            "7b2476fe325113b4"
         ],
         "x": 34,
         "y": 99,
@@ -1592,17 +1235,17 @@
         "h": 162
     },
     {
-        "id": "6f5226c3d3419e05",
+        "id": "c6b82dc737e918bc",
         "type": "group",
-        "z": "ea282c9a1916db76",
+        "z": "d60f98965bf0409c",
         "name": "Battery solutions",
         "style": {
             "label": true
         },
         "nodes": [
-            "0a3bdc2aa08626d5",
-            "09cd251a8a1c8ed2",
-            "fcd9a95f1b45497c"
+            "2c94e4382f2869ca",
+            "64bcf1f04dbbd6f5",
+            "9af5a7904623a82e"
         ],
         "x": 34,
         "y": 579,
@@ -1610,22 +1253,22 @@
         "h": 142
     },
     {
-        "id": "ca7cdbd7beb12727",
+        "id": "ceed73f8bc60e712",
         "type": "group",
-        "z": "ea282c9a1916db76",
+        "z": "d60f98965bf0409c",
         "name": "Import routine",
         "style": {
             "label": true
         },
         "nodes": [
-            "d5538c7d757428cd",
-            "21d353fbb79bab65",
-            "cc62b37cec0aca75",
-            "75ba44f750bf1408",
-            "71822aeb406c67b9",
-            "75c6eae8657baf3f",
-            "e8e9a2482984ece2",
-            "3f16ffc073bb4b4a"
+            "766cb40ec6f263ae",
+            "d8dcda2cbc3cc00e",
+            "834eed358b3d0661",
+            "9ce7a9d690018b01",
+            "f6444602754619c5",
+            "d7a854b56b45db65",
+            "f220de39e40f2d8f",
+            "f96d862ec3b2ecbf"
         ],
         "x": 254,
         "y": 539,
@@ -1633,38 +1276,38 @@
         "h": 182
     },
     {
-        "id": "1b9d9a2cb683bbba",
+        "id": "3864eee6ef12a6cf",
         "type": "group",
-        "z": "ea282c9a1916db76",
+        "z": "d60f98965bf0409c",
         "name": "Decide import or stop",
         "style": {
             "label": true
         },
         "nodes": [
-            "d3c73a6dca461f97",
-            "2a6d963285cea2ba",
-            "cbc44637fd9c21e8",
-            "a6b5d382cfe059f7",
-            "08e66a7a4d5aee4b",
-            "21c2b3f683139a28",
-            "364b6da4bebb7353",
-            "a97682586d7a8650",
-            "eedd3c5e056e808c",
-            "b08d963419a0ef8f",
-            "2649315e8c01a01b",
-            "913c7c41126b2a95",
-            "92cf91937116658c",
-            "965ec6679352d78f",
-            "b2ebdb1934e971af",
-            "55a22f29f0144ebd",
-            "123af548fb46d3fc",
-            "2b2df59d717f740d",
-            "0168fbfe69450274",
-            "98acfc5db8fd84b2",
-            "a46b37b48350cd6c",
-            "695fbd98ef999747",
-            "20e2d0cbf1c5579a",
-            "056683d4c0212e19"
+            "eb7b9310b7255bf1",
+            "58ef2462a9398e6d",
+            "03a2451155697047",
+            "1e568d834ff1e000",
+            "aeeffc28ca9116e3",
+            "b7d4d7c413086e23",
+            "35ca58c8f870157c",
+            "2e79cc6f7e5fd376",
+            "3bb859cb9b639ffa",
+            "66e598d1b9d621b8",
+            "3434f8046ace9f46",
+            "8ef70b102d3efa7b",
+            "f226f40f1a8f6d50",
+            "01b253901b25116d",
+            "7732fdf8f7324a09",
+            "b824e5983fb91749",
+            "60818973c652a28b",
+            "1eae51cada2081bf",
+            "f5ea052a4d4f6b02",
+            "6da488cbeae4a531",
+            "40c95cdba07a902b",
+            "a88c5148ece6f6c0",
+            "ce2748d0e36567f9",
+            "aac3bf9516dbcc4e"
         ],
         "x": 254,
         "y": 59,
@@ -1672,9 +1315,9 @@
         "h": 387
     },
     {
-        "id": "a05f0f93ec78e376",
+        "id": "f7b29c23bc50f575",
         "type": "group",
-        "z": "ea282c9a1916db76",
+        "z": "d60f98965bf0409c",
         "name": "Unhandled exceptions",
         "style": {
             "label": true,
@@ -1682,9 +1325,9 @@
             "color": "#d88a8a"
         },
         "nodes": [
-            "09ee061d1ab97a55",
-            "c6cfcb1bb71f9198",
-            "9d1d3ac35cc47fb3"
+            "896fbea1a27539b7",
+            "d6ce31820356b7f4",
+            "24d2b649f1c319ef"
         ],
         "x": 44,
         "y": 359,
@@ -1692,21 +1335,21 @@
         "h": 82
     },
     {
-        "id": "850a4db192a92f5c",
+        "id": "4c9715590340f74a",
         "type": "group",
-        "z": "0175d4a664d6a895",
-        "g": "953fd66d6e9a5104",
+        "z": "90ba722d19d180d0",
+        "g": "68c1ff5282e98cfc",
         "name": "Loop",
         "style": {
             "label": true
         },
         "nodes": [
-            "ffd2ae9d0c0567db",
-            "d334843b10486744",
-            "871d86a303aff3a2",
-            "ab85be4609428733",
-            "51569e358b758d85",
-            "30cdb945f14cd2de"
+            "5c0e52bab7ca452a",
+            "ee97315d36787b6a",
+            "675f7035505da486",
+            "ec78c1a734f54aa2",
+            "1963c871dda0c6cb",
+            "aab0a177eb87ddf5"
         ],
         "x": 414,
         "y": 99,
@@ -1714,35 +1357,35 @@
         "h": 222
     },
     {
-        "id": "101917fb25d567d6",
+        "id": "b974ba39dc7d0bca",
         "type": "group",
-        "z": "99f6e455efa54b3a",
-        "g": "47b0e8e393df1fc5",
+        "z": "c11340415b97b938",
+        "g": "9f89ee41a453c9a9",
         "name": "API call to Data Source",
         "style": {
             "label": true
         },
         "nodes": [
-            "9a68105b2f6b975c",
-            "eee4e7f3304c26ed",
-            "a7d2619afbf92a40",
-            "054edde1a66b20e2",
-            "c70c81db78db986d",
-            "c4f8b98f5b87d363",
-            "3467770b596d2cd0",
-            "653113bbb5c213d4",
-            "19e3d0f158f3b578",
-            "5908484fee20f236",
-            "efdc5a416dca1c46",
-            "4a12c6ba9d98964e",
-            "b57872813470a1bf",
-            "3a74e3ce419a7fe9",
-            "9cca1192971396d4",
-            "ec7a895564a448a2",
-            "56dd9fa3c398c149",
-            "b54dfd2aee8114c4",
-            "c2a7fd9e34a495f8",
-            "3266909a51aea110"
+            "34fd784e608d9d54",
+            "64ac7813f1f8a906",
+            "8f1db7f696ab7441",
+            "8f918ce3ce0a6c8a",
+            "f69d6b41f3833758",
+            "9363c4bd159453fc",
+            "f96ee4126963036f",
+            "7957ba42cec8c33a",
+            "6859674ee5e989a3",
+            "bcc7f47c83e1d999",
+            "f29836ea1ad52e46",
+            "0c9bbea87173e613",
+            "34b4b46992036a22",
+            "7cbb8bdd50eaebfb",
+            "92916d0b05ad1c8c",
+            "a8ad08cd0c3ddc3d",
+            "1b934ae07c52fa8e",
+            "8d5144b097aa6422",
+            "f624987ffa0e7d13",
+            "a9bcbe42ed707bd0"
         ],
         "x": 254,
         "y": 519,
@@ -1750,33 +1393,33 @@
         "h": 362
     },
     {
-        "id": "1c58bd73aef4538b",
+        "id": "8c1deab0e5e6f11a",
         "type": "group",
-        "z": "99f6e455efa54b3a",
-        "g": "47b0e8e393df1fc5",
+        "z": "c11340415b97b938",
+        "g": "9f89ee41a453c9a9",
         "name": "Update when",
         "style": {
             "label": true
         },
         "nodes": [
-            "4453c2db4c12e57c",
-            "8ecb9358ad2a9548",
-            "a10482f4b176de1c",
-            "6c27d2c4744e1e45",
-            "0af742a1171ddcde",
-            "919bb0e478c3cc38",
-            "daaff12efb064bd6",
-            "8c704ab4f125c10c",
-            "cce5bc49088b006a",
-            "0ab721b9d58d102f",
-            "5389042290f78ae7",
-            "2f4467e62db0af59",
-            "2436febcc68a269d",
-            "7f7d4df28918e455",
-            "a13f6c3e2325368e",
-            "65cb86cc40d09a4f",
-            "401559fcf17d2cc4",
-            "5bd8887b64e21684"
+            "963292f96d950b74",
+            "e5404cfdb2ab9409",
+            "7df5f321724f926e",
+            "877fbda0b5917a30",
+            "cdd87a392dbb639a",
+            "707996bcaabe85a5",
+            "0eacfd9ccf95222c",
+            "96620bc320d1f41e",
+            "7b84c64641b09f1a",
+            "d68ab5d71946310d",
+            "9777db5a45b20653",
+            "de7507b8e2f9830e",
+            "3cc700a138b05de6",
+            "1c88d5249c92d346",
+            "33914fdfaa110ba3",
+            "88e001bdc138d861",
+            "948a83c51a4fc285",
+            "bcc114a3aa31b7e6"
         ],
         "x": 254,
         "y": 299,
@@ -1784,31 +1427,31 @@
         "h": 202
     },
     {
-        "id": "b4d8861efefe4972",
+        "id": "b2852c433afeb8cc",
         "type": "group",
-        "z": "99f6e455efa54b3a",
-        "g": "47b0e8e393df1fc5",
+        "z": "c11340415b97b938",
+        "g": "9f89ee41a453c9a9",
         "name": "Determine strategy",
         "style": {
             "label": true
         },
         "nodes": [
-            "3b03078088842f6c",
-            "2178a721499737da",
-            "7541537e74f52f0f",
-            "f984611e3ccc84c9",
-            "f91c2013220ea334",
-            "eb3ace62bb381ab5",
-            "a51a5cd98b789771",
-            "d94fa194cae868ad",
-            "687936a77e0f906d",
-            "6b2377c655bd05fc",
-            "53c357f45b14b295",
-            "dde6d8513842ee9d",
-            "f68514fd61cab5ee",
-            "e4335777aab93c03",
-            "a4a1979ffbe3c79c",
-            "1da468394e019058"
+            "c440e478825fb651",
+            "7c23c7e9d9c9c21d",
+            "21af2478e7e13247",
+            "94a6aee346dc3833",
+            "d49038e8a4407299",
+            "bb9c63a891fa0e86",
+            "1d6b8b8a07984e20",
+            "143c21e7820f372f",
+            "9684b85dd4952a26",
+            "a0270d19a585a526",
+            "958ddb0cbeb390ca",
+            "36a9fb103ce44403",
+            "d8aabf7646c2f302",
+            "15f02574323644ae",
+            "bc236515982ed0bc",
+            "1dc09a0aae6aa2d7"
         ],
         "x": 254,
         "y": 899,
@@ -1816,25 +1459,25 @@
         "h": 402
     },
     {
-        "id": "edc2a2a28871c43a",
+        "id": "0a55432a91ac4ec8",
         "type": "group",
-        "z": "95b545927e70ace9",
-        "g": "8ff21e1d960e953f",
+        "z": "1d3cf6be03a635b7",
+        "g": "11ce1c9c6dabf691",
         "name": "PID control inputs",
         "style": {
             "label": true,
             "fill": "#ffffff"
         },
         "nodes": [
-            "bc0f60b5ad95db8d",
-            "8a2068076f28f707",
-            "83191e5fbcbb4040",
-            "a26b70853d0c1f33",
-            "28fdc66b87c47def",
-            "5762198fbde44006",
-            "a5dd4127a91f05bf",
-            "f340a342d8960dc5",
-            "657c645d1be89d97"
+            "2fc2aaaf7233eea5",
+            "94479d5e6b3261e9",
+            "c0be8ba44fcac8ab",
+            "aa281f3ee93a6151",
+            "8a4036338bcd1979",
+            "fc7ebb59ccc630d1",
+            "c4e8dbbe77422199",
+            "feac298f995f06c5",
+            "0207a901138bf4ce"
         ],
         "x": 314,
         "y": 59,
@@ -1842,19 +1485,19 @@
         "h": 162
     },
     {
-        "id": "fbc01f9edcc6842a",
+        "id": "ad8b5d8b3606c48b",
         "type": "group",
-        "z": "95b545927e70ace9",
-        "g": "8ff21e1d960e953f",
+        "z": "1d3cf6be03a635b7",
+        "g": "11ce1c9c6dabf691",
         "name": "Advanced features",
         "style": {
             "label": true,
             "fill": "#ffffff"
         },
         "nodes": [
-            "a33b025d071a6e94",
-            "a4a00c57b5d69453",
-            "6bf43ec016ed83ac"
+            "f81b4a5e8214cef1",
+            "409106894fab910f",
+            "b9ab2d12f4d067fa"
         ],
         "x": 914,
         "y": 39,
@@ -1862,20 +1505,20 @@
         "h": 182
     },
     {
-        "id": "d893e2f37a24c25c",
+        "id": "9a620a2a2f96288f",
         "type": "group",
-        "z": "95b545927e70ace9",
-        "g": "af6088abf152ca24",
+        "z": "1d3cf6be03a635b7",
+        "g": "6c638ca874330d9b",
         "name": "",
         "style": {
             "fill": "#ffffff",
             "label": true
         },
         "nodes": [
-            "449b488ed26a70f9",
-            "81656e1f7dd92ea6",
-            "97b610266a045131",
-            "8e1df3c6f38c1053"
+            "32a4f7483671ea38",
+            "9cd824ee2bb19cb0",
+            "8a56bf61cd0c2bdf",
+            "f0173fe22d480af0"
         ],
         "x": 314,
         "y": 299,
@@ -1883,10 +1526,10 @@
         "h": 202
     },
     {
-        "id": "75642cb0b65d0e1e",
+        "id": "d9ae5f41bc83da9b",
         "type": "group",
-        "z": "95b545927e70ace9",
-        "g": "af6088abf152ca24",
+        "z": "1d3cf6be03a635b7",
+        "g": "6c638ca874330d9b",
         "name": "Derivative - incl. bumpless operation",
         "style": {
             "label": true,
@@ -1894,11 +1537,11 @@
             "fill": "#ffffff"
         },
         "nodes": [
-            "4f756da9c8b272a5",
-            "5791fc8607b08141",
-            "b6f33bcaec258e9c",
-            "d341286c1d683cd6",
-            "d1b3c520513823b2"
+            "e55ec15da0d697fa",
+            "ac2fa01660cc55a4",
+            "21add7c0e2d45e21",
+            "820f84951c511215",
+            "e694349a6ea76737"
         ],
         "x": 614,
         "y": 399,
@@ -1906,19 +1549,19 @@
         "h": 142
     },
     {
-        "id": "d8c94b15828961e5",
+        "id": "502610763c97d762",
         "type": "group",
-        "z": "95b545927e70ace9",
-        "g": "af6088abf152ca24",
+        "z": "1d3cf6be03a635b7",
+        "g": "6c638ca874330d9b",
         "name": "Processing required? ",
         "style": {
             "label": true,
             "fill": "#ffffff"
         },
         "nodes": [
-            "02779588813f2ea1",
-            "8ec51e53b2d0f9bb",
-            "e8de4c019d4e5868"
+            "cf38a2aa88332648",
+            "61b64f336cfe23f6",
+            "01dedefe1e7ce9db"
         ],
         "x": 614,
         "y": 299,
@@ -1926,10 +1569,10 @@
         "h": 82
     },
     {
-        "id": "6697a3fa1010723e",
+        "id": "29995cd0b0073ccd",
         "type": "group",
-        "z": "95b545927e70ace9",
-        "g": "c5326024bff42548",
+        "z": "1d3cf6be03a635b7",
+        "g": "eaca266ff7533044",
         "name": "PID controller",
         "style": {
             "label": true,
@@ -1937,26 +1580,26 @@
             "color": "#3f3f3f"
         },
         "nodes": [
-            "8dd243f68e522803",
-            "05ada452851c2f54",
-            "307d9f53546e14f0",
-            "53c69b2484613a04",
-            "325a6ee7699c88ba",
-            "a4f127c2ab2fe440",
-            "a6a12718d0113a94",
-            "dd6ff843a07fb171",
-            "703ad985bc335fec",
-            "3a45b91f874f978f",
-            "33bacec3a2296d98",
-            "d938d61eb9bd05e3",
-            "543f350e89a68994",
-            "79782f0fafc42800",
-            "4ccbd6efdd4517e1",
-            "1de249bcde8d065a",
-            "920232e0b3ca3daf",
-            "b657bfbf3a7eb6a1",
-            "53b2cc35ca8e6dfd",
-            "82c2a3ffbf8605c9"
+            "1ed3fc7e029faf20",
+            "c915c89572f2197d",
+            "329f3cbc671249c7",
+            "8421219bb5e59589",
+            "453e21c86b6336d6",
+            "e01b146cd708f9f5",
+            "4a75544e000d0772",
+            "ed2ad4363b1754e8",
+            "0849b31850b001e2",
+            "c654cb2271f9ada1",
+            "0a41c005e73b7f1f",
+            "41f9974be9e16501",
+            "3236985a34b149bc",
+            "62b85cc02674c18b",
+            "62f1b3c9088c874c",
+            "99a492d34dc9cbf7",
+            "a762a06160c44f50",
+            "a4adb78b5507e5fc",
+            "749c0a41454bc101",
+            "9db7ba7db486e683"
         ],
         "x": 314,
         "y": 619,
@@ -1964,10 +1607,10 @@
         "h": 482
     },
     {
-        "id": "6d773e100cbddf8f",
+        "id": "c0422f307e2b7a3f",
         "type": "group",
-        "z": "95b545927e70ace9",
-        "g": "c5326024bff42548",
+        "z": "1d3cf6be03a635b7",
+        "g": "eaca266ff7533044",
         "name": "Distribution",
         "style": {
             "label": true,
@@ -1975,8 +1618,8 @@
             "color": "#3f3f3f"
         },
         "nodes": [
-            "c93703549f08db02",
-            "6322e003511c0da0"
+            "15e1815e0781a8a6",
+            "edcb4ef7c4ac95a7"
         ],
         "x": 314,
         "y": 1119,
@@ -1984,19 +1627,19 @@
         "h": 82
     },
     {
-        "id": "1f2beb406508348d",
+        "id": "c1a0dc6672015b4e",
         "type": "group",
-        "z": "45268219e4d1f409",
-        "g": "a1f61dc615ba5d8f",
+        "z": "8ba5b00d69c6f447",
+        "g": "733019b51f77eb7a",
         "name": "UI helper | set bounds for charge levels",
         "style": {
             "label": true,
             "stroke": "#3f93cf"
         },
         "nodes": [
-            "52067ef98127cc7f",
-            "f66801007c26edf9",
-            "d0a92a6efa9b40a4"
+            "4c11202ace08f27c",
+            "f749f46ef2094218",
+            "7a16b8de0fa74077"
         ],
         "x": 1394,
         "y": 159,
@@ -2004,25 +1647,25 @@
         "h": 82
     },
     {
-        "id": "8b2ee74f2a91f366",
+        "id": "240a191aa7efc2c6",
         "type": "group",
-        "z": "48ac861af1dcedb4",
-        "g": "0f9a11f670a00bdc",
+        "z": "23a4e27f08db4d94",
+        "g": "7f93f37162d70288",
         "name": "Loop",
         "style": {
             "label": true
         },
         "nodes": [
-            "a421130d3420519b",
-            "e889142eb16dd5f1",
-            "4b978b994b36bd63",
-            "3a50c75b4a9cca8c",
-            "4a4eb3f1f1ef88f8",
-            "0f7e0893df46d003",
-            "3bc02df09d28dd4c",
-            "a619bbd2218439a8",
-            "566b73ac710d9716",
-            "35b0c7bbe1aa6cbb"
+            "3e22c7996a237cb0",
+            "9fcead626e6d0bf4",
+            "0fc3d288748feb7a",
+            "7f8d8ad31fe0e884",
+            "a02164b5186fa08b",
+            "6c1de9041948c7f3",
+            "06a37ec093f227f7",
+            "5502544e6949ec66",
+            "3c73013253faf6e4",
+            "9823984049faf224"
         ],
         "x": 74,
         "y": 459,
@@ -2030,22 +1673,22 @@
         "h": 82
     },
     {
-        "id": "cadf8c33c17cef4a",
+        "id": "0f5639b779d2555c",
         "type": "group",
-        "z": "48ac861af1dcedb4",
-        "g": "f76d0a5b93c10ffb",
+        "z": "23a4e27f08db4d94",
+        "g": "eefa9cb839c2d5b2",
         "name": "Loop",
         "style": {
             "label": true
         },
         "nodes": [
-            "978b076ba86e2f14",
-            "0e5b65282514ed13",
-            "251ac10c55bdf4bc",
-            "8214339bae8245c8",
-            "a2940e104a89e48f",
-            "040c74ee6223db71",
-            "f7c4aa8d96bf64fd"
+            "60e78d6e0a3941ea",
+            "6660c9537dc4dd69",
+            "aa6220c6fbb17566",
+            "552cae4fe4d77d1a",
+            "5dbe8ec3e8f7943f",
+            "c1f8e4728f5711c0",
+            "f3e989b84435a7ec"
         ],
         "x": 314,
         "y": 1319,
@@ -2053,19 +1696,19 @@
         "h": 222
     },
     {
-        "id": "0168fbfe69450274",
+        "id": "f5ea052a4d4f6b02",
         "type": "group",
-        "z": "ea282c9a1916db76",
-        "g": "1b9d9a2cb683bbba",
+        "z": "d60f98965bf0409c",
+        "g": "3864eee6ef12a6cf",
         "name": "UI helper | set bounds for charge levels",
         "style": {
             "label": true,
             "stroke": "#3f93cf"
         },
         "nodes": [
-            "e9407dbd0616c6ef",
-            "d7137b33033d22a3",
-            "1e5222f2eac079b6"
+            "3f6f7094b3c725a4",
+            "5ddb4e59c65e3f2c",
+            "cc30a0b748b12089"
         ],
         "x": 1584,
         "y": 319,
@@ -2073,20 +1716,20 @@
         "h": 82
     },
     {
-        "id": "056683d4c0212e19",
+        "id": "aac3bf9516dbcc4e",
         "type": "group",
-        "z": "ea282c9a1916db76",
-        "g": "1b9d9a2cb683bbba",
+        "z": "d60f98965bf0409c",
+        "g": "3864eee6ef12a6cf",
         "name": "UI",
         "style": {
             "stroke": "#3f93cf",
             "label": true
         },
         "nodes": [
-            "4cc9caf9bcfade98",
-            "7b5b6de45bacd44f",
-            "4890c6058de00446",
-            "3312e425d31523f4"
+            "a12c3943bfa94b58",
+            "8ca65cea7933f573",
+            "c66d3097858658c1",
+            "a0755655090bf55f"
         ],
         "x": 1574,
         "y": 179,
@@ -2094,109 +1737,109 @@
         "h": 122
     },
     {
-        "id": "2f4467e62db0af59",
+        "id": "de7507b8e2f9830e",
         "type": "junction",
-        "z": "99f6e455efa54b3a",
-        "g": "1c58bd73aef4538b",
+        "z": "c11340415b97b938",
+        "g": "8c1deab0e5e6f11a",
         "x": 640,
         "y": 340,
         "wires": [
             [
-                "daaff12efb064bd6"
+                "0eacfd9ccf95222c"
             ]
         ]
     },
     {
-        "id": "5762198fbde44006",
+        "id": "fc7ebb59ccc630d1",
         "type": "junction",
-        "z": "95b545927e70ace9",
-        "g": "edc2a2a28871c43a",
+        "z": "1d3cf6be03a635b7",
+        "g": "0a55432a91ac4ec8",
         "x": 460,
         "y": 100,
         "wires": [
             [
-                "f340a342d8960dc5"
+                "feac298f995f06c5"
             ]
         ]
     },
     {
-        "id": "f340a342d8960dc5",
+        "id": "feac298f995f06c5",
         "type": "junction",
-        "z": "95b545927e70ace9",
-        "g": "edc2a2a28871c43a",
+        "z": "1d3cf6be03a635b7",
+        "g": "0a55432a91ac4ec8",
         "x": 700,
         "y": 100,
         "wires": [
             [
-                "a5dd4127a91f05bf",
-                "657c645d1be89d97"
+                "c4e8dbbe77422199",
+                "0207a901138bf4ce"
             ]
         ]
     },
     {
-        "id": "657c645d1be89d97",
+        "id": "0207a901138bf4ce",
         "type": "junction",
-        "z": "95b545927e70ace9",
-        "g": "edc2a2a28871c43a",
+        "z": "1d3cf6be03a635b7",
+        "g": "0a55432a91ac4ec8",
         "x": 720,
         "y": 120,
         "wires": [
             [
-                "8a2068076f28f707"
+                "94479d5e6b3261e9"
             ]
         ]
     },
     {
-        "id": "3b7e225dc182bb5c",
+        "id": "3d7a88cb39de079b",
         "type": "junction",
-        "z": "45268219e4d1f409",
-        "g": "a1f61dc615ba5d8f",
+        "z": "8ba5b00d69c6f447",
+        "g": "733019b51f77eb7a",
         "x": 1440,
         "y": 260,
         "wires": [
             [
-                "2cf3625539d84467"
+                "c484ab904b03e8f0"
             ]
         ]
     },
     {
-        "id": "84d53eaf9442ab0c",
+        "id": "ecd0aa22731ed65e",
         "type": "junction",
-        "z": "48ac861af1dcedb4",
+        "z": "23a4e27f08db4d94",
         "x": 40,
         "y": 360,
         "wires": [
             [
-                "d275a0ab915f2347"
+                "99acf563ae5fd9cc"
             ]
         ]
     },
     {
-        "id": "ce1f525f7b16288e",
+        "id": "6038c75de7aac7e5",
         "type": "junction",
-        "z": "48ac861af1dcedb4",
+        "z": "23a4e27f08db4d94",
         "x": 1380,
         "y": 680,
         "wires": [
             [
-                "860e283819486c58",
-                "c7de808391c56099",
-                "9d453126a447f823",
-                "d7b73d46113bf2da",
-                "c4a33dedf4f3e995"
+                "616b4e11c9cd9b86",
+                "4a62d45425318b8f",
+                "c62651c153461a9b",
+                "ea0955393fdf3a5a",
+                "5e91d1e843b5bf9c"
             ]
         ]
     },
     {
-        "id": "2b2df59d717f740d",
+        "id": "1eae51cada2081bf",
         "type": "junction",
-        "z": "ea282c9a1916db76",
-        "g": "1b9d9a2cb683bbba",
+        "z": "d60f98965bf0409c",
+        "g": "3864eee6ef12a6cf",
         "x": 1560,
         "y": 420,
         "wires": [
             [
-                "cc62b37cec0aca75"
+                "834eed358b3d0661"
             ]
         ]
     },
@@ -2323,3601 +1966,10 @@
         }
     },
     {
-        "id": "a6add08339130589",
-        "type": "ui_tab",
-        "name": "Home",
-        "icon": "dashboard",
-        "disabled": false,
-        "hidden": false
-    },
-    {
-        "id": "dc57595d461379a1",
-        "type": "ui_group",
-        "name": "Battery 1",
-        "tab": "a6add08339130589",
-        "order": 2,
-        "disp": true,
-        "width": "12",
-        "collapse": true,
-        "className": ""
-    },
-    {
-        "id": "54991681ca09e29d",
-        "type": "ui_group",
-        "name": "Battery 2",
-        "tab": "a6add08339130589",
-        "order": 3,
-        "disp": true,
-        "width": "12",
-        "collapse": false,
-        "className": ""
-    },
-    {
-        "id": "ab91aa3e54c948ec",
-        "type": "ui_group",
-        "name": "Battery 3",
-        "tab": "a6add08339130589",
-        "order": 4,
-        "disp": true,
-        "width": "12",
-        "collapse": true,
-        "className": ""
-    },
-    {
-        "id": "9bfeb0b645386875",
-        "type": "ui_group",
-        "name": "Grid",
-        "tab": "a6add08339130589",
-        "order": 1,
-        "disp": true,
-        "width": "12",
-        "collapse": false,
-        "className": ""
-    },
-    {
-        "id": "7ec432c49bd7aad2",
-        "type": "debug",
-        "z": "0a25621f3d1c985f",
-        "g": "4776ad4f0339c6ae",
-        "name": "M1 Forcible mode",
-        "active": true,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "payload",
-        "targetType": "msg",
-        "statusVal": "",
-        "statusType": "auto",
-        "x": 610,
-        "y": 200,
-        "wires": []
-    },
-    {
-        "id": "6c10fd50e5e23c5c",
-        "type": "debug",
-        "z": "0a25621f3d1c985f",
-        "g": "4776ad4f0339c6ae",
-        "name": "M1 power",
-        "active": true,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "payload",
-        "targetType": "msg",
-        "statusVal": "",
-        "statusType": "auto",
-        "x": 580,
-        "y": 260,
-        "wires": []
-    },
-    {
-        "id": "807fecff3dd1e9d7",
-        "type": "api-call-service",
-        "z": "0a25621f3d1c985f",
-        "g": "4776ad4f0339c6ae",
-        "name": "Output charge/discharge/stop M1",
-        "server": "176d29a.6f648d6",
-        "version": 7,
-        "debugenabled": false,
-        "action": "select.select_option",
-        "floorId": [],
-        "areaId": [],
-        "deviceId": [],
-        "entityId": [
-            "select.marstek_m1_forcible_charge_discharge"
-        ],
-        "labelId": [],
-        "data": "{\"option\":\"{{ payload }}\"}",
-        "dataType": "json",
-        "mergeContext": "",
-        "mustacheAltTags": false,
-        "outputProperties": [],
-        "queue": "none",
-        "blockInputOverrides": true,
-        "domain": "select",
-        "service": "select_option",
-        "x": 360,
-        "y": 200,
-        "wires": [
-            [
-                "7ec432c49bd7aad2"
-            ]
-        ]
-    },
-    {
-        "id": "c32afffb5ac57d79",
-        "type": "api-call-service",
-        "z": "0a25621f3d1c985f",
-        "g": "4776ad4f0339c6ae",
-        "name": "Output (dis)charge power M1",
-        "server": "176d29a.6f648d6",
-        "version": 7,
-        "debugenabled": false,
-        "action": "number.set_value",
-        "floorId": [],
-        "areaId": [],
-        "deviceId": [],
-        "entityId": [
-            "number.marstek_m1_forcible_discharge_power",
-            "number.marstek_m1_forcible_charge_power"
-        ],
-        "labelId": [],
-        "data": "{\"value\":\"{{ payload }}\"}",
-        "dataType": "json",
-        "mergeContext": "",
-        "mustacheAltTags": false,
-        "outputProperties": [],
-        "queue": "none",
-        "blockInputOverrides": true,
-        "domain": "number",
-        "service": "set_value",
-        "x": 340,
-        "y": 260,
-        "wires": [
-            [
-                "6c10fd50e5e23c5c"
-            ]
-        ]
-    },
-    {
-        "id": "931cccdaaeafbd38",
-        "type": "inject",
-        "z": "0a25621f3d1c985f",
-        "g": "d94668c8ae9cf8a1",
-        "name": "Charge",
-        "props": [
-            {
-                "p": "payload"
-            },
-            {
-                "p": "topic",
-                "vt": "str"
-            }
-        ],
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": 0.1,
-        "topic": "charge_mode",
-        "payload": "charge",
-        "payloadType": "str",
-        "x": 150,
-        "y": 360,
-        "wires": [
-            [
-                "f0629b49c28c5864"
-            ]
-        ]
-    },
-    {
-        "id": "5caaf9fa7ecd954b",
-        "type": "function",
-        "z": "0a25621f3d1c985f",
-        "g": "4776ad4f0339c6ae",
-        "name": "Input",
-        "func": "let test_array = [];\nlet charge_mode = flow.get(\"forcible_charge_discharge\")||\"stop\";\nlet power = Number(flow.get(\"power\"));\n\n// Charge mode\ntest_array.push({payload: charge_mode});\n// Power\ntest_array.push({payload: power});\n\nreturn test_array;",
-        "outputs": 2,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 130,
-        "y": 200,
-        "wires": [
-            [
-                "807fecff3dd1e9d7"
-            ],
-            [
-                "c32afffb5ac57d79"
-            ]
-        ]
-    },
-    {
-        "id": "ac7f5f881b0f026f",
+        "id": "77e00747c15d33d8",
         "type": "api-current-state",
-        "z": "0a25621f3d1c985f",
-        "g": "fe54093811b6a7fe",
-        "name": "Master Control Mode",
-        "server": "176d29a.6f648d6",
-        "version": 3,
-        "outputs": 1,
-        "halt_if": "",
-        "halt_if_type": "str",
-        "halt_if_compare": "is",
-        "entity_id": "input_select.marstek_master_battery_mode",
-        "state_type": "str",
-        "blockInputOverrides": true,
-        "outputProperties": [
-            {
-                "property": "payload",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entityState"
-            },
-            {
-                "property": "data",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entity"
-            },
-            {
-                "property": "master_mode",
-                "propertyType": "flow",
-                "value": "",
-                "valueType": "entityState"
-            }
-        ],
-        "for": "0",
-        "forType": "num",
-        "forUnits": "minutes",
-        "override_topic": false,
-        "state_location": "payload",
-        "override_payload": "msg",
-        "entity_location": "data",
-        "override_data": "msg",
-        "x": 360,
-        "y": 100,
-        "wires": [
-            [
-                "869beb2c2332637b"
-            ]
-        ]
-    },
-    {
-        "id": "869beb2c2332637b",
-        "type": "switch",
-        "z": "0a25621f3d1c985f",
-        "g": "fe54093811b6a7fe",
-        "name": "when in \"Manual Control\" mode",
-        "property": "payload",
-        "propertyType": "msg",
-        "rules": [
-            {
-                "t": "eq",
-                "v": "Manual control",
-                "vt": "str"
-            }
-        ],
-        "checkall": "true",
-        "repair": false,
-        "outputs": 1,
-        "x": 630,
-        "y": 100,
-        "wires": [
-            [
-                "5caaf9fa7ecd954b"
-            ]
-        ]
-    },
-    {
-        "id": "16e609e6f5bfaff8",
-        "type": "inject",
-        "z": "0a25621f3d1c985f",
-        "g": "fe54093811b6a7fe",
-        "name": "Do a test",
-        "props": [
-            {
-                "p": "payload"
-            },
-            {
-                "p": "topic",
-                "vt": "str"
-            }
-        ],
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": 0.1,
-        "topic": "",
-        "payload": "",
-        "payloadType": "date",
-        "x": 160,
-        "y": 100,
-        "wires": [
-            [
-                "ac7f5f881b0f026f"
-            ]
-        ]
-    },
-    {
-        "id": "f0629b49c28c5864",
-        "type": "function",
-        "z": "0a25621f3d1c985f",
-        "g": "d94668c8ae9cf8a1",
-        "name": "charge state",
-        "func": "flow.set(\"forcible_charge_discharge\", msg.payload); // stop, charge, discharge\n\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 370,
-        "y": 400,
-        "wires": [
-            []
-        ]
-    },
-    {
-        "id": "5cfda233ce27dc73",
-        "type": "inject",
-        "z": "0a25621f3d1c985f",
-        "g": "d94668c8ae9cf8a1",
-        "name": "Discharge",
-        "props": [
-            {
-                "p": "payload"
-            },
-            {
-                "p": "topic",
-                "vt": "str"
-            }
-        ],
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": 0.1,
-        "topic": "charge_mode",
-        "payload": "discharge",
-        "payloadType": "str",
-        "x": 160,
-        "y": 400,
-        "wires": [
-            [
-                "f0629b49c28c5864"
-            ]
-        ]
-    },
-    {
-        "id": "f4e777264f65f640",
-        "type": "inject",
-        "z": "0a25621f3d1c985f",
-        "g": "d94668c8ae9cf8a1",
-        "name": "Stop",
-        "props": [
-            {
-                "p": "payload"
-            },
-            {
-                "p": "topic",
-                "vt": "str"
-            }
-        ],
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": 0.1,
-        "topic": "charge_mode",
-        "payload": "stop",
-        "payloadType": "str",
-        "x": 150,
-        "y": 440,
-        "wires": [
-            [
-                "f0629b49c28c5864"
-            ]
-        ]
-    },
-    {
-        "id": "bc9e96111f996807",
-        "type": "inject",
-        "z": "0a25621f3d1c985f",
-        "g": "d6af2a36d0dfdda5",
-        "name": "200 W",
-        "props": [
-            {
-                "p": "payload"
-            },
-            {
-                "p": "topic",
-                "vt": "str"
-            }
-        ],
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": 0.1,
-        "topic": "power",
-        "payload": "200",
-        "payloadType": "num",
-        "x": 570,
-        "y": 360,
-        "wires": [
-            [
-                "8cd5b26ec5d86f60"
-            ]
-        ]
-    },
-    {
-        "id": "275647d6fa79f142",
-        "type": "inject",
-        "z": "0a25621f3d1c985f",
-        "g": "d6af2a36d0dfdda5",
-        "name": "1 W",
-        "props": [
-            {
-                "p": "payload"
-            },
-            {
-                "p": "topic",
-                "vt": "str"
-            }
-        ],
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": 0.1,
-        "topic": "power",
-        "payload": "1",
-        "payloadType": "num",
-        "x": 570,
-        "y": 400,
-        "wires": [
-            [
-                "8cd5b26ec5d86f60"
-            ]
-        ]
-    },
-    {
-        "id": "26629155a2d9c3ba",
-        "type": "inject",
-        "z": "0a25621f3d1c985f",
-        "g": "d6af2a36d0dfdda5",
-        "name": "0 W",
-        "props": [
-            {
-                "p": "payload"
-            },
-            {
-                "p": "topic",
-                "vt": "str"
-            }
-        ],
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": 0.1,
-        "topic": "power",
-        "payload": "0",
-        "payloadType": "num",
-        "x": 570,
-        "y": 440,
-        "wires": [
-            [
-                "8cd5b26ec5d86f60"
-            ]
-        ]
-    },
-    {
-        "id": "8cd5b26ec5d86f60",
-        "type": "function",
-        "z": "0a25621f3d1c985f",
-        "g": "d6af2a36d0dfdda5",
-        "name": "set power",
-        "func": "flow.set(\"power\", msg.payload); // Watt\n\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 800,
-        "y": 400,
-        "wires": [
-            []
-        ]
-    },
-    {
-        "id": "952dcb76faf9377b",
-        "type": "inject",
-        "z": "0a25621f3d1c985f",
-        "g": "23508a0784b7a764",
-        "name": "",
-        "props": [
-            {
-                "p": "payload"
-            },
-            {
-                "p": "topic",
-                "vt": "str"
-            }
-        ],
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": 0.1,
-        "topic": "",
-        "payload": "",
-        "payloadType": "date",
-        "x": 160,
-        "y": 540,
-        "wires": [
-            [
-                "1de0ea92dde0cb92"
-            ]
-        ]
-    },
-    {
-        "id": "d37894c2b1e074da",
-        "type": "function",
-        "z": "0a25621f3d1c985f",
-        "g": "23508a0784b7a764",
-        "name": "For each (init)",
-        "func": "// loop through the number of batteries set by the user\nmsg.battery_index = msg.battery_count;\n\n// Init an array for battery status and value information\nmsg.batteries = [];\n\n// Continue\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 480,
-        "y": 540,
-        "wires": [
-            [
-                "32c18b304ab18eef"
-            ]
-        ]
-    },
-    {
-        "id": "e2c98a4a11d3119b",
-        "type": "function",
-        "z": "0a25621f3d1c985f",
-        "g": "23508a0784b7a764",
-        "name": "Mapping",
-        "func": "node.warn(msg.battery_index);\n\n// { id: \"M1\", \n//       power: M1_power, charging_max: M1_charging_max, discharging_max: M1_discharging_max,\n//       soc: M1_soc, soc_min: M1_soc_min, soc_max: M1_soc_max,\n//       rs485: M1_control_mode \n//     }\n\n// Map to batteries array\nmsg.batteries.push({\n    id: `M${msg.battery_index}`,\n    power: msg.battery_power,\n    charging_max: msg.max_charge_power,\n    discharging_max: msg.max_discharge_power,\n    soc: msg.battery_state_of_charge,\n    soc_max: msg.charging_cutoff_capacity,\n    soc_min: msg.discharging_cutoff_capacity,\n    inverter: msg.inverter_state,\n    cap_remaining: msg.battery_remaining_capacity,\n    rs485: msg.rs485_control_mode\n    });\n\n// Step index down\nmsg.battery_index -= 1;\n\n// Continue\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 140,
-        "y": 720,
-        "wires": [
-            [
-                "7d491da9cff1228d"
-            ]
-        ]
-    },
-    {
-        "id": "7d491da9cff1228d",
-        "type": "switch",
-        "z": "0a25621f3d1c985f",
-        "g": "23508a0784b7a764",
-        "name": "Loop until",
-        "property": "battery_index",
-        "propertyType": "msg",
-        "rules": [
-            {
-                "t": "gt",
-                "v": "0",
-                "vt": "num"
-            },
-            {
-                "t": "else"
-            }
-        ],
-        "checkall": "true",
-        "repair": false,
-        "outputs": 2,
-        "x": 140,
-        "y": 760,
-        "wires": [
-            [
-                "32c18b304ab18eef"
-            ],
-            [
-                "ed583566b7d2e5a5"
-            ]
-        ]
-    },
-    {
-        "id": "ed583566b7d2e5a5",
-        "type": "debug",
-        "z": "0a25621f3d1c985f",
-        "g": "23508a0784b7a764",
-        "name": "Loop result",
-        "active": true,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "true",
-        "targetType": "full",
-        "statusVal": "",
-        "statusType": "auto",
-        "x": 150,
-        "y": 800,
-        "wires": []
-    },
-    {
-        "id": "1de0ea92dde0cb92",
-        "type": "api-current-state",
-        "z": "0a25621f3d1c985f",
-        "g": "23508a0784b7a764",
-        "name": "Battery count",
-        "server": "176d29a.6f648d6",
-        "version": 3,
-        "outputs": 1,
-        "halt_if": "",
-        "halt_if_type": "str",
-        "halt_if_compare": "is",
-        "entity_id": "input_number.house_battery_count",
-        "state_type": "str",
-        "blockInputOverrides": true,
-        "outputProperties": [
-            {
-                "property": "payload",
-                "propertyType": "msg",
-                "value": "number",
-                "valueType": "entityState"
-            },
-            {
-                "property": "data",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entity"
-            },
-            {
-                "property": "battery_count",
-                "propertyType": "msg",
-                "value": "number",
-                "valueType": "entityState"
-            }
-        ],
-        "for": "0",
-        "forType": "num",
-        "forUnits": "minutes",
-        "override_topic": false,
-        "state_location": "payload",
-        "override_payload": "msg",
-        "entity_location": "data",
-        "override_data": "msg",
-        "x": 310,
-        "y": 540,
-        "wires": [
-            [
-                "d37894c2b1e074da"
-            ]
-        ]
-    },
-    {
-        "id": "40b65d5d85625cf3",
-        "type": "api-current-state",
-        "z": "0a25621f3d1c985f",
-        "g": "23508a0784b7a764",
-        "name": "SoC",
-        "server": "176d29a.6f648d6",
-        "version": 3,
-        "outputs": 1,
-        "halt_if": "",
-        "halt_if_type": "str",
-        "halt_if_compare": "is",
-        "entity_id": "sensor.marstek_m{{battery_index}}_battery_state_of_charge",
-        "state_type": "str",
-        "blockInputOverrides": true,
-        "outputProperties": [
-            {
-                "property": "payload",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entityState"
-            },
-            {
-                "property": "data",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entity"
-            },
-            {
-                "property": "battery_state_of_charge",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entityState"
-            }
-        ],
-        "for": "0",
-        "forType": "num",
-        "forUnits": "minutes",
-        "override_topic": false,
-        "state_location": "payload",
-        "override_payload": "msg",
-        "entity_location": "data",
-        "override_data": "msg",
-        "x": 310,
-        "y": 640,
-        "wires": [
-            [
-                "ef5d062ab8c5730b"
-            ]
-        ]
-    },
-    {
-        "id": "b6036af3515b400f",
-        "type": "api-current-state",
-        "z": "0a25621f3d1c985f",
-        "g": "23508a0784b7a764",
-        "name": "Inverter state",
-        "server": "176d29a.6f648d6",
-        "version": 3,
-        "outputs": 1,
-        "halt_if": "",
-        "halt_if_type": "str",
-        "halt_if_compare": "is",
-        "entity_id": "sensor.marstek_m{{battery_index}}_inverter_state",
-        "state_type": "str",
-        "blockInputOverrides": true,
-        "outputProperties": [
-            {
-                "property": "payload",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entityState"
-            },
-            {
-                "property": "data",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entity"
-            },
-            {
-                "property": "inverter_state",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entityState"
-            }
-        ],
-        "for": "0",
-        "forType": "num",
-        "forUnits": "minutes",
-        "override_topic": false,
-        "state_location": "payload",
-        "override_payload": "msg",
-        "entity_location": "data",
-        "override_data": "msg",
-        "x": 330,
-        "y": 680,
-        "wires": [
-            [
-                "b1a0880f8fb62bf2"
-            ]
-        ]
-    },
-    {
-        "id": "ef5d062ab8c5730b",
-        "type": "api-current-state",
-        "z": "0a25621f3d1c985f",
-        "g": "23508a0784b7a764",
-        "name": "SoC min",
-        "server": "176d29a.6f648d6",
-        "version": 3,
-        "outputs": 1,
-        "halt_if": "",
-        "halt_if_type": "str",
-        "halt_if_compare": "is",
-        "entity_id": "number.marstek_m{{battery_index}}_discharging_cutoff_capacity",
-        "state_type": "str",
-        "blockInputOverrides": true,
-        "outputProperties": [
-            {
-                "property": "payload",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entityState"
-            },
-            {
-                "property": "data",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entity"
-            },
-            {
-                "property": "discharging_cutoff_capacity",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entityState"
-            }
-        ],
-        "for": "0",
-        "forType": "num",
-        "forUnits": "minutes",
-        "override_topic": false,
-        "state_location": "payload",
-        "override_payload": "msg",
-        "entity_location": "data",
-        "override_data": "msg",
-        "x": 480,
-        "y": 640,
-        "wires": [
-            [
-                "317a70d47e45df87"
-            ]
-        ]
-    },
-    {
-        "id": "317a70d47e45df87",
-        "type": "api-current-state",
-        "z": "0a25621f3d1c985f",
-        "g": "23508a0784b7a764",
-        "name": "SoC max",
-        "server": "176d29a.6f648d6",
-        "version": 3,
-        "outputs": 1,
-        "halt_if": "",
-        "halt_if_type": "str",
-        "halt_if_compare": "is",
-        "entity_id": "number.marstek_m{{battery_index}}_charging_cutoff_capacity",
-        "state_type": "str",
-        "blockInputOverrides": true,
-        "outputProperties": [
-            {
-                "property": "payload",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entityState"
-            },
-            {
-                "property": "data",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entity"
-            },
-            {
-                "property": "charging_cutoff_capacity",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entityState"
-            }
-        ],
-        "for": "0",
-        "forType": "num",
-        "forUnits": "minutes",
-        "override_topic": false,
-        "state_location": "payload",
-        "override_payload": "msg",
-        "entity_location": "data",
-        "override_data": "msg",
-        "x": 680,
-        "y": 640,
-        "wires": [
-            [
-                "b6036af3515b400f"
-            ]
-        ]
-    },
-    {
-        "id": "544d7fe378e8f4f1",
-        "type": "api-current-state",
-        "z": "0a25621f3d1c985f",
-        "g": "23508a0784b7a764",
-        "name": "Max discharge power",
-        "server": "176d29a.6f648d6",
-        "version": 3,
-        "outputs": 1,
-        "halt_if": "",
-        "halt_if_type": "str",
-        "halt_if_compare": "is",
-        "entity_id": "number.marstek_m{{battery_index}}_max_discharge_power",
-        "state_type": "str",
-        "blockInputOverrides": true,
-        "outputProperties": [
-            {
-                "property": "payload",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entityState"
-            },
-            {
-                "property": "data",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entity"
-            },
-            {
-                "property": "max_discharge_power",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entityState"
-            }
-        ],
-        "for": "0",
-        "forType": "num",
-        "forUnits": "minutes",
-        "override_topic": false,
-        "state_location": "payload",
-        "override_payload": "msg",
-        "entity_location": "data",
-        "override_data": "msg",
-        "x": 720,
-        "y": 600,
-        "wires": [
-            [
-                "40b65d5d85625cf3"
-            ]
-        ]
-    },
-    {
-        "id": "b1a0880f8fb62bf2",
-        "type": "api-current-state",
-        "z": "0a25621f3d1c985f",
-        "g": "23508a0784b7a764",
-        "name": "Capacity remaining",
-        "server": "176d29a.6f648d6",
-        "version": 3,
-        "outputs": 1,
-        "halt_if": "",
-        "halt_if_type": "str",
-        "halt_if_compare": "is",
-        "entity_id": "sensor.marstek_m{{battery_index}}_battery_remaining_capacity",
-        "state_type": "str",
-        "blockInputOverrides": true,
-        "outputProperties": [
-            {
-                "property": "payload",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entityState"
-            },
-            {
-                "property": "data",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entity"
-            },
-            {
-                "property": "battery_remaining_capacity",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entityState"
-            }
-        ],
-        "for": "0",
-        "forType": "num",
-        "forUnits": "minutes",
-        "override_topic": false,
-        "state_location": "payload",
-        "override_payload": "msg",
-        "entity_location": "data",
-        "override_data": "msg",
-        "x": 510,
-        "y": 680,
-        "wires": [
-            [
-                "e2c98a4a11d3119b"
-            ]
-        ]
-    },
-    {
-        "id": "10e04cfa04d1fb5f",
-        "type": "api-current-state",
-        "z": "0a25621f3d1c985f",
-        "g": "23508a0784b7a764",
-        "name": "Max charge power",
-        "server": "176d29a.6f648d6",
-        "version": 3,
-        "outputs": 1,
-        "halt_if": "",
-        "halt_if_type": "str",
-        "halt_if_compare": "is",
-        "entity_id": "number.marstek_m{{battery_index}}_max_charge_power",
-        "state_type": "str",
-        "blockInputOverrides": true,
-        "outputProperties": [
-            {
-                "property": "payload",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entityState"
-            },
-            {
-                "property": "data",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entity"
-            },
-            {
-                "property": "max_charge_power",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entityState"
-            }
-        ],
-        "for": "0",
-        "forType": "num",
-        "forUnits": "minutes",
-        "override_topic": false,
-        "state_location": "payload",
-        "override_payload": "msg",
-        "entity_location": "data",
-        "override_data": "msg",
-        "x": 510,
-        "y": 600,
-        "wires": [
-            [
-                "544d7fe378e8f4f1"
-            ]
-        ]
-    },
-    {
-        "id": "3cb20d31ca53816b",
-        "type": "api-current-state",
-        "z": "0a25621f3d1c985f",
-        "g": "23508a0784b7a764",
-        "name": "Power",
-        "server": "176d29a.6f648d6",
-        "version": 3,
-        "outputs": 1,
-        "halt_if": "",
-        "halt_if_type": "str",
-        "halt_if_compare": "is",
-        "entity_id": "sensor.marstek_m{{battery_index}}_battery_power",
-        "state_type": "str",
-        "blockInputOverrides": false,
-        "outputProperties": [
-            {
-                "property": "data",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entity"
-            },
-            {
-                "property": "payload",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entityState"
-            },
-            {
-                "property": "battery_power",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entityState"
-            }
-        ],
-        "for": "0",
-        "forType": "num",
-        "forUnits": "minutes",
-        "override_topic": false,
-        "state_location": "payload",
-        "override_payload": "msg",
-        "entity_location": "data",
-        "override_data": "msg",
-        "x": 310,
-        "y": 600,
-        "wires": [
-            [
-                "10e04cfa04d1fb5f"
-            ]
-        ]
-    },
-    {
-        "id": "32c18b304ab18eef",
-        "type": "api-current-state",
-        "z": "0a25621f3d1c985f",
-        "g": "23508a0784b7a764",
-        "name": "Control mode",
-        "server": "176d29a.6f648d6",
-        "version": 3,
-        "outputs": 1,
-        "halt_if": "",
-        "halt_if_type": "str",
-        "halt_if_compare": "is",
-        "entity_id": "select.marstek_m{{battery_index}}_rs485_control_mode",
-        "state_type": "str",
-        "blockInputOverrides": true,
-        "outputProperties": [
-            {
-                "property": "payload",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entityState"
-            },
-            {
-                "property": "data",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entity"
-            },
-            {
-                "property": "rs485_control_mode",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entityState"
-            }
-        ],
-        "for": "0",
-        "forType": "num",
-        "forUnits": "minutes",
-        "override_topic": false,
-        "state_location": "payload",
-        "override_payload": "msg",
-        "entity_location": "data",
-        "override_data": "msg",
-        "x": 160,
-        "y": 600,
-        "wires": [
-            [
-                "3cb20d31ca53816b"
-            ]
-        ]
-    },
-    {
-        "id": "721c6c9f8abb8939",
-        "type": "inject",
-        "z": "0a25621f3d1c985f",
-        "g": "99dab2f005d99056",
-        "name": "",
-        "props": [
-            {
-                "p": "payload"
-            },
-            {
-                "p": "topic",
-                "vt": "str"
-            }
-        ],
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": 0.1,
-        "topic": "",
-        "payload": "",
-        "payloadType": "date",
-        "x": 980,
-        "y": 540,
-        "wires": [
-            [
-                "85e53fe14fe8c336"
-            ]
-        ]
-    },
-    {
-        "id": "85e53fe14fe8c336",
-        "type": "function",
-        "z": "0a25621f3d1c985f",
-        "g": "99dab2f005d99056",
-        "name": "For each (inti)",
-        "func": "const value = \"charge\"; //msg.payload;\nconst target = \"select.marstek_m1_forcible_charge_discharge\"; //msg.topic;\n\nmsg.payload = {\n    \"action\": \"select.select_option\",\n    \"target\": {\n        \"entity_id\": [target]\n    },\n    \"data\": {\n        \"option\": value\n    }\n}\n\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 1140,
-        "y": 540,
-        "wires": [
-            [
-                "53bdff08247dc43b"
-            ]
-        ]
-    },
-    {
-        "id": "53bdff08247dc43b",
-        "type": "api-call-service",
-        "z": "0a25621f3d1c985f",
-        "g": "99dab2f005d99056",
-        "name": "Set Marstek Battery",
-        "server": "176d29a.6f648d6",
-        "version": 7,
-        "debugenabled": false,
-        "action": "",
-        "floorId": [],
-        "areaId": [],
-        "deviceId": [],
-        "entityId": [],
-        "labelId": [],
-        "data": "",
-        "dataType": "json",
-        "mergeContext": "",
-        "mustacheAltTags": false,
-        "outputProperties": [],
-        "queue": "last",
-        "blockInputOverrides": false,
-        "domain": "select",
-        "service": "select_option",
-        "x": 1330,
-        "y": 540,
-        "wires": [
-            []
-        ]
-    },
-    {
-        "id": "6b3e5f2f22e3df05",
-        "type": "inject",
-        "z": "0a25621f3d1c985f",
-        "g": "137e6287c81f0267",
-        "name": "",
-        "props": [
-            {
-                "p": "payload"
-            },
-            {
-                "p": "prioritize_battery",
-                "v": "3",
-                "vt": "num"
-            }
-        ],
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": 0.1,
-        "topic": "",
-        "payload": "",
-        "payloadType": "date",
-        "x": 160,
-        "y": 900,
-        "wires": [
-            [
-                "61aeb6b570e5d0f6"
-            ]
-        ]
-    },
-    {
-        "id": "61aeb6b570e5d0f6",
-        "type": "function",
-        "z": "0a25621f3d1c985f",
-        "g": "137e6287c81f0267",
-        "name": "Battery order",
-        "func": "// msg.batteries (original order)\n// let oldArray = [{id:\"M1\"},{id:\"M2\"},{id:\"M3\"}];\nlet oldArray = [1,2,3,4];\n\n// Prioritize the Mth battery\nconst M = RED.util.getMessageProperty(msg,\"prioritize_battery\") || 1;\n\n// N equals the number of items to take from the front to the back of the array, effectivly rotating battery priority\nconst N = M - 1; // base-0 version of M\nnode.status({fill:\"blue\",shape:\"ring\",text:`N = ${N}`});\n\n// 1. Check if the array is valid and long enough\nif (!Array.isArray(oldArray) || oldArray.length < N) {\n    // Send an error or the original array back if the array is invalid/too short\n    node.error(`Array is not valid or shorter than ${N} items.`, msg);\n    return null; \n}\n\n// 2. Get the first N items (these will go to the back)\n// slice(0, N) retrieves elements from the start (index 0) up to index N (exclusive).\nlet firstN = oldArray.slice(0, N);\n\n// 3. Get the remaining items (these will stay at the front)\n// slice(N) retrieves elements from index N to the end of the array.\nlet remaining = oldArray.slice(N);\n\n// 4. Concatenate them: remaining items (front) + first N items (back)\nlet newArray = remaining.concat(firstN);\n\n// 5. Place the new array back into msg.batteries\nmsg.batteries = newArray;\n\nreturn msg;\n",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 330,
-        "y": 900,
-        "wires": [
-            [
-                "149a6d03c4420699"
-            ]
-        ]
-    },
-    {
-        "id": "149a6d03c4420699",
-        "type": "debug",
-        "z": "0a25621f3d1c985f",
-        "g": "137e6287c81f0267",
-        "name": "Result",
-        "active": true,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "batteries",
-        "targetType": "msg",
-        "statusVal": "",
-        "statusType": "auto",
-        "x": 470,
-        "y": 900,
-        "wires": []
-    },
-    {
-        "id": "1b87bb9331aa7957",
-        "type": "inject",
-        "z": "0a25621f3d1c985f",
-        "g": "a9c604eb640d5087",
-        "name": "",
-        "props": [
-            {
-                "p": "payload"
-            },
-            {
-                "p": "topic",
-                "vt": "str"
-            }
-        ],
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": 0.1,
-        "topic": "",
-        "payload": "",
-        "payloadType": "date",
-        "x": 160,
-        "y": 1020,
-        "wires": [
-            [
-                "1c53d1727770d10f"
-            ]
-        ]
-    },
-    {
-        "id": "03999a11700893e1",
-        "type": "api-current-state",
-        "z": "0a25621f3d1c985f",
-        "g": "a9c604eb640d5087",
-        "name": "Cheapest hour",
-        "server": "176d29a.6f648d6",
-        "version": 3,
-        "outputs": 1,
-        "halt_if": "",
-        "halt_if_type": "str",
-        "halt_if_compare": "is",
-        "entity_id": "sensor.cheapest_hour",
-        "state_type": "str",
-        "blockInputOverrides": true,
-        "outputProperties": [
-            {
-                "property": "payload",
-                "propertyType": "msg",
-                "value": "string",
-                "valueType": "entityState"
-            },
-            {
-                "property": "data",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entity"
-            }
-        ],
-        "for": "0",
-        "forType": "num",
-        "forUnits": "minutes",
-        "override_topic": false,
-        "state_location": "payload",
-        "override_payload": "msg",
-        "entity_location": "data",
-        "override_data": "msg",
-        "x": 460,
-        "y": 1020,
-        "wires": [
-            [
-                "dd12fb024f91a46c"
-            ]
-        ]
-    },
-    {
-        "id": "06742153914f176c",
-        "type": "debug",
-        "z": "0a25621f3d1c985f",
-        "g": "a9c604eb640d5087",
-        "name": "Cheapest hours",
-        "active": true,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "payload",
-        "targetType": "msg",
-        "statusVal": "",
-        "statusType": "auto",
-        "x": 940,
-        "y": 1020,
-        "wires": []
-    },
-    {
-        "id": "77a60a41e79103b6",
-        "type": "api-render-template",
-        "z": "0a25621f3d1c985f",
-        "g": "a9c604eb640d5087",
-        "name": "Cheapest template",
-        "server": "176d29a.6f648d6",
-        "version": 0,
-        "template": "{% from 'cheapest_energy_hours.jinja' import cheapest_energy_hours %}\n{{ cheapest_energy_hours(\n    sensor=\"sensor.zonneplan_current_electricity_tariff\",\n    source_settings=\"zonneplan\",\n    hours=2,\n    mode=\"all\"\n) | to_json }}",
-        "resultsLocation": "payload",
-        "resultsLocationType": "msg",
-        "templateLocation": "",
-        "templateLocationType": "none",
-        "x": 470,
-        "y": 1100,
-        "wires": [
-            [
-                "d21932c2d5c60e3c"
-            ]
-        ]
-    },
-    {
-        "id": "bc3b82ace59b9797",
-        "type": "debug",
-        "z": "0a25621f3d1c985f",
-        "g": "a9c604eb640d5087",
-        "name": "Cheapest template",
-        "active": false,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "payload",
-        "targetType": "msg",
-        "statusVal": "",
-        "statusType": "auto",
-        "x": 950,
-        "y": 1100,
-        "wires": []
-    },
-    {
-        "id": "0ff3238209d01e07",
-        "type": "function",
-        "z": "0a25621f3d1c985f",
-        "g": "a9c604eb640d5087",
-        "name": "function 1",
-        "func": "const output = RED.util.getMessageProperty(msg,\"payload.start\");\nnode.status({fill:\"blue\",shape:\"dot\",text:`${output}`});\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 920,
-        "y": 1160,
-        "wires": [
-            []
-        ]
-    },
-    {
-        "id": "b43975f0bd7d3bcc",
-        "type": "json",
-        "z": "0a25621f3d1c985f",
-        "g": "a9c604eb640d5087",
-        "name": "",
-        "property": "payload",
-        "action": "obj",
-        "pretty": false,
-        "x": 770,
-        "y": 1100,
-        "wires": [
-            [
-                "bc3b82ace59b9797",
-                "0ff3238209d01e07"
-            ]
-        ]
-    },
-    {
-        "id": "1c53d1727770d10f",
-        "type": "function",
-        "z": "0a25621f3d1c985f",
-        "g": "a9c604eb640d5087",
-        "name": "Timing",
-        "func": "// add execution marker\nRED.util.setMessageProperty(msg,\"execution_start\",Date.now()); \n\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 290,
-        "y": 1020,
-        "wires": [
-            [
-                "03999a11700893e1",
-                "77a60a41e79103b6"
-            ]
-        ]
-    },
-    {
-        "id": "dd12fb024f91a46c",
-        "type": "function",
-        "z": "0a25621f3d1c985f",
-        "g": "a9c604eb640d5087",
-        "name": "Time trap",
-        "func": "// add execution marker\nlet execution_end = Date.now();\nRED.util.setMessageProperty(msg, \"execution_end\", execution_end);\n\n// retrieve execution markers\nlet execution_start = RED.util.getMessageProperty(msg,\"execution_start\");\n\n// report execution time\nif (execution_start !== undefined && execution_end !== undefined) {\n    // exec time\n    let execution_time = (execution_end - execution_start) / 1000; // seconds\n    // report\n    if (execution_time <= 0) node.status({ fill: \"red\", shape: \"dot\", text: `negative or zero timing` });\n    if (execution_time > 0) node.status({ fill: \"green\", shape: \"dot\", text: `${execution_time} sec`});\n    if (execution_time >= 0.7) node.status({ fill: \"yellow\", shape: \"dot\", text: `${execution_time} sec` });\n    if (execution_time >= 1) node.status({ fill: \"red\", shape: \"dot\", text: `${execution_time} sec` });\n\n} else {\n    node.status({fill:\"grey\",shape:\"dot\",text:\"timing error\"});\n}\n\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 640,
-        "y": 1020,
-        "wires": [
-            [
-                "6904fb44493109bc"
-            ]
-        ]
-    },
-    {
-        "id": "d21932c2d5c60e3c",
-        "type": "function",
-        "z": "0a25621f3d1c985f",
-        "g": "a9c604eb640d5087",
-        "name": "Time trap",
-        "func": "// add execution marker\nlet execution_end = Date.now();\nRED.util.setMessageProperty(msg, \"execution_end\", execution_end);\n\n// retrieve execution markers\nlet execution_start = RED.util.getMessageProperty(msg,\"execution_start\");\n\n// report execution time\nif (execution_start !== undefined && execution_end !== undefined) {\n    // exec time\n    let execution_time = (execution_end - execution_start) / 1000; // seconds\n    // report\n    if (execution_time <= 0) node.status({ fill: \"red\", shape: \"dot\", text: `negative or zero timing` });\n    if (execution_time > 0) node.status({ fill: \"green\", shape: \"dot\", text: `${execution_time} sec`});\n    if (execution_time >= 0.7) node.status({ fill: \"yellow\", shape: \"dot\", text: `${execution_time} sec` });\n    if (execution_time >= 1) node.status({ fill: \"red\", shape: \"dot\", text: `${execution_time} sec` });\n\n} else {\n    node.status({fill:\"grey\",shape:\"dot\",text:\"timing error\"});\n}\n\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 640,
-        "y": 1100,
-        "wires": [
-            [
-                "b43975f0bd7d3bcc"
-            ]
-        ]
-    },
-    {
-        "id": "6904fb44493109bc",
-        "type": "json",
-        "z": "0a25621f3d1c985f",
-        "g": "a9c604eb640d5087",
-        "name": "",
-        "property": "payload",
-        "action": "str",
-        "pretty": false,
-        "x": 770,
-        "y": 1020,
-        "wires": [
-            [
-                "06742153914f176c"
-            ]
-        ]
-    },
-    {
-        "id": "a79347dc7b41ced3",
-        "type": "comment",
-        "z": "0a25621f3d1c985f",
-        "g": "a9c604eb640d5087",
-        "name": "Notes",
-        "info": "Using a template node is 4x slower... \n... than a state node.\n\nHowever, having multiple template_sensors \nin HA and only using 1 of them is not ideal either.\nAnd letting users comment and uncomment the right sensors \nis too unfriendly. This would lead to large amounts of code\nin the config.yaml and even the few lines that are \ncurrently there generate a lot of help requests.\n\nUX should be paramount.",
-        "x": 250,
-        "y": 1100,
-        "wires": []
-    },
-    {
-        "id": "71b212e67de97103",
-        "type": "inject",
-        "z": "0a25621f3d1c985f",
-        "g": "66edb01751dea0f8",
-        "name": "1st flow test",
-        "props": [
-            {
-                "p": "payload"
-            },
-            {
-                "p": "topic",
-                "vt": "str"
-            },
-            {
-                "p": "target",
-                "v": "Target #1",
-                "vt": "str"
-            },
-            {
-                "p": "advanced_settings.discharge_disabled",
-                "v": "true",
-                "vt": "bool"
-            }
-        ],
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": 0.1,
-        "topic": "Flow routing",
-        "payload": "",
-        "payloadType": "date",
-        "x": 990,
-        "y": 660,
-        "wires": [
-            [
-                "4cff99f65954edec"
-            ]
-        ]
-    },
-    {
-        "id": "4cff99f65954edec",
-        "type": "change",
-        "z": "0a25621f3d1c985f",
-        "g": "66edb01751dea0f8",
-        "name": "strategy routing",
-        "rules": [
-            {
-                "t": "set",
-                "p": "strategy.trace",
-                "pt": "msg",
-                "to": "[\t   strategy.trace,\t   {\t       \"flow\": target,\t       \"flow_settings\": advanced_settings,\t       \"timestamp\": $now()\t   } \t]",
-                "tot": "jsonata"
-            }
-        ],
-        "action": "",
-        "property": "",
-        "from": "",
-        "to": "",
-        "reg": false,
-        "x": 1220,
-        "y": 660,
-        "wires": [
-            [
-                "7cdff9e39aebf2c5"
-            ]
-        ]
-    },
-    {
-        "id": "7cdff9e39aebf2c5",
-        "type": "debug",
-        "z": "0a25621f3d1c985f",
-        "g": "66edb01751dea0f8",
-        "name": "route",
-        "active": true,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "true",
-        "targetType": "full",
-        "statusVal": "",
-        "statusType": "auto",
-        "x": 1370,
-        "y": 660,
-        "wires": []
-    },
-    {
-        "id": "da820c91ddee7552",
-        "type": "inject",
-        "z": "0a25621f3d1c985f",
-        "g": "66edb01751dea0f8",
-        "name": "2nd flow test",
-        "props": [
-            {
-                "p": "payload"
-            },
-            {
-                "p": "topic",
-                "vt": "str"
-            },
-            {
-                "p": "target",
-                "v": "Target #2",
-                "vt": "str"
-            },
-            {
-                "p": "strategy.route",
-                "v": "{\"flow\":\"Target #1\",\"timestamp\":\"2026-01-02T00:28:25.448Z\"}",
-                "vt": "json"
-            }
-        ],
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": 0.1,
-        "topic": "Flow routing",
-        "payload": "",
-        "payloadType": "date",
-        "x": 990,
-        "y": 700,
-        "wires": [
-            [
-                "4cff99f65954edec"
-            ]
-        ]
-    },
-    {
-        "id": "7e3a9ac873bdc028",
-        "type": "inject",
-        "z": "0a25621f3d1c985f",
-        "g": "66edb01751dea0f8",
-        "name": "No target test",
-        "props": [
-            {
-                "p": "payload"
-            },
-            {
-                "p": "topic",
-                "vt": "str"
-            }
-        ],
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": 0.1,
-        "topic": "bad actor",
-        "payload": "",
-        "payloadType": "date",
-        "x": 990,
-        "y": 740,
-        "wires": [
-            [
-                "4cff99f65954edec"
-            ]
-        ]
-    },
-    {
-        "id": "0a8e0cf84f3d5f42",
-        "type": "inject",
-        "z": "0a25621f3d1c985f",
-        "g": "84df681959deba36",
-        "name": "abracadabra",
-        "props": [
-            {
-                "p": "payload"
-            },
-            {
-                "p": "topic",
-                "vt": "str"
-            }
-        ],
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": 0.1,
-        "topic": "",
-        "payload": "",
-        "payloadType": "date",
-        "x": 990,
-        "y": 840,
-        "wires": [
-            [
-                "fd2c1bd1c1bb9628"
-            ]
-        ]
-    },
-    {
-        "id": "fd2c1bd1c1bb9628",
-        "type": "function",
-        "z": "0a25621f3d1c985f",
-        "g": "84df681959deba36",
-        "name": "log/warn/error",
-        "func": "// node.log(\"abracadabra log\");\n// node.warn(\"abracadabra warning\");\n// node.error(\"abracadabra error\", msg); // msg triggers catch node\n\nconst log = global.get('logger');\n\nlog(this,\"test message\");\nlog(this,\"test message\",\"log\");\nlog(this,\"test message\",\"warn\");\nlog(this,\"test message\",\"error\");\n\n// node.warn(msg.log);\n\nconst name = env.get(\"NR_FLOW_NAME\");\nnode.status({fill:\"blue\",shape:\"dot\",text:`Flow name: ${name}`});\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 1160,
-        "y": 840,
-        "wires": [
-            [
-                "de74be27ad34f443"
-            ]
-        ]
-    },
-    {
-        "id": "de74be27ad34f443",
-        "type": "ha-fire-event",
-        "z": "0a25621f3d1c985f",
-        "g": "84df681959deba36",
-        "name": "Show on debug board",
-        "server": "176d29a.6f648d6",
-        "version": 0,
-        "event": "update_trace_sensor",
-        "data": "{\t   \"trace\": strategy.trace ? strategy.trace : [],\t   \"log\": log ? log : []\t}",
-        "dataType": "jsonata",
-        "x": 1380,
-        "y": 840,
-        "wires": [
-            []
-        ]
-    },
-    {
-        "id": "98879159d5e86be8",
-        "type": "function",
-        "z": "0a25621f3d1c985f",
-        "g": "84df681959deba36",
-        "name": "a bad function node",
-        "func": "const log = global.get('logger');\n\nlog(this,\"Error message\", \"error\");\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 1190,
-        "y": 900,
-        "wires": [
-            [
-                "1ef6879cecdd47fe"
-            ]
-        ]
-    },
-    {
-        "id": "24d378c6060d0323",
-        "type": "inject",
-        "z": "0a25621f3d1c985f",
-        "g": "84df681959deba36",
-        "name": "Force error",
-        "props": [
-            {
-                "p": "payload"
-            },
-            {
-                "p": "topic",
-                "vt": "str"
-            }
-        ],
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": 0.1,
-        "topic": "",
-        "payload": "",
-        "payloadType": "date",
-        "x": 1000,
-        "y": 900,
-        "wires": [
-            [
-                "98879159d5e86be8"
-            ]
-        ]
-    },
-    {
-        "id": "1ef6879cecdd47fe",
-        "type": "debug",
-        "z": "0a25621f3d1c985f",
-        "g": "84df681959deba36",
-        "name": "stays zero",
-        "active": true,
-        "tosidebar": false,
-        "console": false,
-        "tostatus": true,
-        "complete": "payload",
-        "targetType": "msg",
-        "statusVal": "",
-        "statusType": "counter",
-        "x": 1390,
-        "y": 900,
-        "wires": []
-    },
-    {
-        "id": "803767396fa679ed",
-        "type": "inject",
-        "z": "68f2a63283f405e0",
-        "name": "21:30 switch off",
-        "props": [
-            {
-                "p": "payload"
-            },
-            {
-                "p": "topic",
-                "vt": "str"
-            }
-        ],
-        "repeat": "",
-        "crontab": "30 21 * * *",
-        "once": false,
-        "onceDelay": 0.1,
-        "topic": "",
-        "payload": "",
-        "payloadType": "date",
-        "x": 150,
-        "y": 60,
-        "wires": [
-            [
-                "411cefe91d46cc88"
-            ]
-        ]
-    },
-    {
-        "id": "411cefe91d46cc88",
-        "type": "api-call-service",
-        "z": "68f2a63283f405e0",
-        "name": "Close-in boiler off",
-        "server": "176d29a.6f648d6",
-        "version": 7,
-        "debugenabled": false,
-        "action": "switch.turn_off",
-        "floorId": [],
-        "areaId": [],
-        "deviceId": [],
-        "entityId": [
-            "switch.athom_smart_plug_v2_f255b3_switch"
-        ],
-        "labelId": [],
-        "data": "",
-        "dataType": "jsonata",
-        "mergeContext": "",
-        "mustacheAltTags": false,
-        "outputProperties": [],
-        "queue": "none",
-        "blockInputOverrides": true,
-        "domain": "switch",
-        "service": "turn_off",
-        "x": 390,
-        "y": 60,
-        "wires": [
-            []
-        ]
-    },
-    {
-        "id": "23e1b7cd9875d4bb",
-        "type": "api-call-service",
-        "z": "68f2a63283f405e0",
-        "name": "Close-in boiler on",
-        "server": "176d29a.6f648d6",
-        "version": 7,
-        "debugenabled": false,
-        "action": "switch.turn_on",
-        "floorId": [],
-        "areaId": [],
-        "deviceId": [],
-        "entityId": [
-            "switch.athom_smart_plug_v2_f255b3_switch"
-        ],
-        "labelId": [],
-        "data": "",
-        "dataType": "jsonata",
-        "mergeContext": "",
-        "mustacheAltTags": false,
-        "outputProperties": [],
-        "queue": "none",
-        "blockInputOverrides": true,
-        "domain": "switch",
-        "service": "turn_on",
-        "x": 390,
-        "y": 120,
-        "wires": [
-            []
-        ]
-    },
-    {
-        "id": "62c90b19dd6db3a7",
-        "type": "inject",
-        "z": "68f2a63283f405e0",
-        "name": "07:00 switch on",
-        "props": [
-            {
-                "p": "payload"
-            },
-            {
-                "p": "topic",
-                "vt": "str"
-            }
-        ],
-        "repeat": "",
-        "crontab": "00 07 * * *",
-        "once": false,
-        "onceDelay": 0.1,
-        "topic": "",
-        "payload": "",
-        "payloadType": "date",
-        "x": 150,
-        "y": 120,
-        "wires": [
-            [
-                "23e1b7cd9875d4bb"
-            ]
-        ]
-    },
-    {
-        "id": "9afb63606c29bf41",
-        "type": "function",
-        "z": "a5fa1fcc1b306096",
-        "name": "get all entities",
-        "func": "// Get all entities from global\nconst allEntities = global.get('homeassistant.homeAssistant.states');\nmsg.all_entities = allEntities;\nreturn msg;\n",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 360,
-        "y": 280,
-        "wires": [
-            [
-                "58d6c7b724b10666",
-                "e740f315724f3d1a",
-                "e60f983d4392917d",
-                "9d500a3c6b154999"
-            ]
-        ]
-    },
-    {
-        "id": "765f822f5f64f3a9",
-        "type": "inject",
-        "z": "a5fa1fcc1b306096",
-        "name": "Initialize",
-        "props": [
-            {
-                "p": "payload"
-            },
-            {
-                "p": "topic",
-                "vt": "str"
-            }
-        ],
-        "repeat": "180",
-        "crontab": "",
-        "once": true,
-        "onceDelay": "1",
-        "topic": "",
-        "payload": "",
-        "payloadType": "date",
-        "x": 200,
-        "y": 280,
-        "wires": [
-            [
-                "9afb63606c29bf41"
-            ]
-        ]
-    },
-    {
-        "id": "c659d02c18f850a9",
-        "type": "ui_dropdown",
-        "z": "a5fa1fcc1b306096",
-        "g": "795071f84cc65671",
-        "name": "",
-        "label": "Battery 1 | RS485 control mode",
-        "tooltip": "Enabled/disabled sensor",
-        "place": "Select option",
-        "group": "dc57595d461379a1",
-        "order": 0,
-        "width": 0,
-        "height": 0,
-        "passthru": true,
-        "multiple": false,
-        "options": [],
-        "payload": "",
-        "topic": "topic",
-        "topicType": "msg",
-        "className": "",
-        "x": 1010,
-        "y": 260,
-        "wires": [
-            [
-                "3323e8b0f6c0ee75"
-            ]
-        ]
-    },
-    {
-        "id": "3323e8b0f6c0ee75",
-        "type": "function",
-        "z": "a5fa1fcc1b306096",
-        "g": "e9025250f91b9eb0",
-        "name": "set input_text",
-        "func": "const value = msg.payload;\nconst target = msg.topic;\n\nmsg.payload = {\n    \"action\": \"input_text.set_value\",\n    \"target\": {\n        \"entity_id\": [target]\n    },\n    \"data\": {\n        \"value\": value\n    }\n}\n\n\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 1330,
-        "y": 284,
-        "wires": [
-            [
-                "edf81a129949f7af"
-            ]
-        ]
-    },
-    {
-        "id": "028a4c9c51e7eccd",
-        "type": "ui_dropdown",
-        "z": "a5fa1fcc1b306096",
-        "g": "795071f84cc65671",
-        "name": "",
-        "label": "Battery 2 | RS485 control mode",
-        "tooltip": "",
-        "place": "Select option",
-        "group": "54991681ca09e29d",
-        "order": 0,
-        "width": 0,
-        "height": 0,
-        "passthru": true,
-        "multiple": false,
-        "options": [],
-        "payload": "",
-        "topic": "topic",
-        "topicType": "msg",
-        "className": "",
-        "x": 1010,
-        "y": 300,
-        "wires": [
-            [
-                "3323e8b0f6c0ee75"
-            ]
-        ]
-    },
-    {
-        "id": "aa7fa18db5e480cc",
-        "type": "ui_dropdown",
-        "z": "a5fa1fcc1b306096",
-        "g": "795071f84cc65671",
-        "name": "",
-        "label": "Battery 3 | RS485 control mode",
-        "tooltip": "",
-        "place": "Select option",
-        "group": "ab91aa3e54c948ec",
-        "order": 0,
-        "width": 0,
-        "height": 0,
-        "passthru": true,
-        "multiple": false,
-        "options": [],
-        "payload": "",
-        "topic": "topic",
-        "topicType": "msg",
-        "className": "",
-        "x": 1010,
-        "y": 340,
-        "wires": [
-            [
-                "3323e8b0f6c0ee75"
-            ]
-        ]
-    },
-    {
-        "id": "64d24e6545b1f86f",
-        "type": "api-current-state",
-        "z": "a5fa1fcc1b306096",
-        "g": "0d03e2a33f3a64b3",
-        "name": "",
-        "server": "176d29a.6f648d6",
-        "version": 3,
-        "outputs": 1,
-        "halt_if": "",
-        "halt_if_type": "str",
-        "halt_if_compare": "is",
-        "entity_id": "input_text.hbc_entity_m1_control_mode",
-        "state_type": "str",
-        "blockInputOverrides": true,
-        "outputProperties": [
-            {
-                "property": "payload",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entityState"
-            },
-            {
-                "property": "data",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entity"
-            },
-            {
-                "property": "topic",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "triggerId"
-            }
-        ],
-        "for": "0",
-        "forType": "num",
-        "forUnits": "minutes",
-        "override_topic": false,
-        "state_location": "payload",
-        "override_payload": "msg",
-        "entity_location": "data",
-        "override_data": "msg",
-        "x": 725,
-        "y": 260,
-        "wires": [
-            [
-                "c659d02c18f850a9"
-            ]
-        ],
-        "l": false
-    },
-    {
-        "id": "edf81a129949f7af",
-        "type": "api-call-service",
-        "z": "a5fa1fcc1b306096",
-        "g": "e9025250f91b9eb0",
-        "name": "Set persistant (dynamic)",
-        "server": "176d29a.6f648d6",
-        "version": 7,
-        "debugenabled": true,
-        "action": "",
-        "floorId": [],
-        "areaId": [],
-        "deviceId": [],
-        "entityId": [],
-        "labelId": [],
-        "data": "",
-        "dataType": "json",
-        "mergeContext": "",
-        "mustacheAltTags": false,
-        "outputProperties": [],
-        "queue": "none",
-        "blockInputOverrides": false,
-        "domain": "input_text",
-        "service": "set_value",
-        "x": 1610,
-        "y": 280,
-        "wires": [
-            []
-        ]
-    },
-    {
-        "id": "58d6c7b724b10666",
-        "type": "function",
-        "z": "a5fa1fcc1b306096",
-        "g": "937c3952d6bb2e19",
-        "name": "selects",
-        "func": "const allEntities = RED.util.getMessageProperty(msg,\"all_entities\");\n\nlet selectOptions = [];\n\n// Loop through all entities\nfor (const [entityId, entityState] of Object.entries(allEntities)) {\n    // Filter on 'sensor' domain\n    if (entityId.startsWith('select.')) {\n\n        // Label for user: use friendly_name, or entity_id\n        const name = entityState.attributes.friendly_name || entityId;\n        const obj = {};\n        obj[name] = entityId;\n        selectOptions.push(obj); \n    }\n}\n\n// Provide the UI Dropdown node with options\nmsg.options = selectOptions;\n\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 580,
-        "y": 280,
-        "wires": [
-            [
-                "64d24e6545b1f86f",
-                "3805ea99193c192c",
-                "79aede9e29152eb5"
-            ]
-        ]
-    },
-    {
-        "id": "c04872de572310e0",
-        "type": "inject",
-        "z": "a5fa1fcc1b306096",
-        "g": "9873daf982c701e7",
-        "name": "",
-        "props": [
-            {
-                "p": "payload"
-            },
-            {
-                "p": "topic",
-                "vt": "str"
-            }
-        ],
-        "repeat": "",
-        "crontab": "",
-        "once": false,
-        "onceDelay": 0.1,
-        "topic": "",
-        "payload": "",
-        "payloadType": "date",
-        "x": 300,
-        "y": 1000,
-        "wires": [
-            [
-                "f8b1b99ed5b34b59",
-                "c223121624220b75"
-            ]
-        ]
-    },
-    {
-        "id": "f8b1b99ed5b34b59",
-        "type": "api-current-state",
-        "z": "a5fa1fcc1b306096",
-        "g": "9873daf982c701e7",
-        "name": "get config",
-        "server": "176d29a.6f648d6",
-        "version": 3,
-        "outputs": 1,
-        "halt_if": "",
-        "halt_if_type": "str",
-        "halt_if_compare": "is",
-        "entity_id": "input_text.gekozen_sensor_entity_picker",
-        "state_type": "str",
-        "blockInputOverrides": true,
-        "outputProperties": [
-            {
-                "property": "payload",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entityState"
-            },
-            {
-                "property": "data",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entity"
-            },
-            {
-                "property": "entity_id",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entityState"
-            }
-        ],
-        "for": "0",
-        "forType": "num",
-        "forUnits": "minutes",
-        "override_topic": false,
-        "state_location": "payload",
-        "override_payload": "msg",
-        "entity_location": "data",
-        "override_data": "msg",
-        "x": 460,
-        "y": 1000,
-        "wires": [
-            [
-                "7a4b7e517f4cf506"
-            ]
-        ]
-    },
-    {
-        "id": "7bc1318c6e070317",
-        "type": "debug",
-        "z": "a5fa1fcc1b306096",
-        "g": "9873daf982c701e7",
-        "name": "Value from configured config",
-        "active": true,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "true",
-        "targetType": "full",
-        "statusVal": "",
-        "statusType": "auto",
-        "x": 840,
-        "y": 980,
-        "wires": []
-    },
-    {
-        "id": "7a4b7e517f4cf506",
-        "type": "api-current-state",
-        "z": "a5fa1fcc1b306096",
-        "g": "9873daf982c701e7",
-        "name": "get value",
-        "server": "176d29a.6f648d6",
-        "version": 3,
-        "outputs": 1,
-        "halt_if": "",
-        "halt_if_type": "str",
-        "halt_if_compare": "is",
-        "entity_id": "{{ entity_id }}",
-        "state_type": "str",
-        "blockInputOverrides": false,
-        "outputProperties": [
-            {
-                "property": "payload",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entityState"
-            },
-            {
-                "property": "data",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entity"
-            }
-        ],
-        "for": "0",
-        "forType": "num",
-        "forUnits": "minutes",
-        "override_topic": false,
-        "state_location": "payload",
-        "override_payload": "msg",
-        "entity_location": "data",
-        "override_data": "msg",
-        "x": 620,
-        "y": 980,
-        "wires": [
-            [
-                "7bc1318c6e070317"
-            ]
-        ]
-    },
-    {
-        "id": "c223121624220b75",
-        "type": "api-current-state",
-        "z": "a5fa1fcc1b306096",
-        "g": "9873daf982c701e7",
-        "name": "",
-        "server": "176d29a.6f648d6",
-        "version": 3,
-        "outputs": 1,
-        "halt_if": "",
-        "halt_if_type": "str",
-        "halt_if_compare": "is",
-        "entity_id": "sensor.m1_battery_charging_in_w",
-        "state_type": "str",
-        "blockInputOverrides": true,
-        "outputProperties": [
-            {
-                "property": "payload",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entityState"
-            },
-            {
-                "property": "data",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entity"
-            }
-        ],
-        "for": "0",
-        "forType": "num",
-        "forUnits": "minutes",
-        "override_topic": false,
-        "state_location": "payload",
-        "override_payload": "msg",
-        "entity_location": "data",
-        "override_data": "msg",
-        "x": 740,
-        "y": 1060,
-        "wires": [
-            []
-        ]
-    },
-    {
-        "id": "7df02adfcd4128ea",
-        "type": "ui_dropdown",
-        "z": "a5fa1fcc1b306096",
-        "g": "795071f84cc65671",
-        "name": "",
-        "label": "Battery 1 | Power",
-        "tooltip": "e.g. sensor.marstek_m1_battery_power",
-        "place": "Select option",
-        "group": "dc57595d461379a1",
-        "order": 0,
-        "width": 0,
-        "height": 0,
-        "passthru": true,
-        "multiple": false,
-        "options": [],
-        "payload": "",
-        "topic": "topic",
-        "topicType": "msg",
-        "className": "",
-        "x": 970,
-        "y": 500,
-        "wires": [
-            [
-                "3323e8b0f6c0ee75"
-            ]
-        ]
-    },
-    {
-        "id": "e740f315724f3d1a",
-        "type": "function",
-        "z": "a5fa1fcc1b306096",
-        "g": "937c3952d6bb2e19",
-        "name": "sensors",
-        "func": "const allEntities = RED.util.getMessageProperty(msg,\"all_entities\");\n\nlet selectOptions = [];\n\n// Loop through all entities\nfor (const [entityId, entityState] of Object.entries(allEntities)) {\n    // Filter on 'sensor' domain\n    if (entityId.startsWith('sensor.')) {\n\n        // Label for user: use friendly_name, or entity_id\n        const name = entityState.attributes.friendly_name || entityId;\n        const obj = {};\n        obj[name] = entityId;\n        selectOptions.push(obj); \n    }\n}\n\n// Provide the UI Dropdown node with options\nmsg.options = selectOptions;\n\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 580,
-        "y": 460,
-        "wires": [
-            [
-                "967320583833cbad",
-                "892e1829e04b12de",
-                "15d0a55aad6896dc",
-                "a0c32b752bed188a",
-                "521c90d39990183f"
-            ]
-        ]
-    },
-    {
-        "id": "3805ea99193c192c",
-        "type": "api-current-state",
-        "z": "a5fa1fcc1b306096",
-        "g": "0d03e2a33f3a64b3",
-        "name": "",
-        "server": "176d29a.6f648d6",
-        "version": 3,
-        "outputs": 1,
-        "halt_if": "",
-        "halt_if_type": "str",
-        "halt_if_compare": "is",
-        "entity_id": "input_text.hbc_entity_m2_control_mode",
-        "state_type": "str",
-        "blockInputOverrides": true,
-        "outputProperties": [
-            {
-                "property": "payload",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entityState"
-            },
-            {
-                "property": "data",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entity"
-            },
-            {
-                "property": "topic",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "triggerId"
-            }
-        ],
-        "for": "0",
-        "forType": "num",
-        "forUnits": "minutes",
-        "override_topic": false,
-        "state_location": "payload",
-        "override_payload": "msg",
-        "entity_location": "data",
-        "override_data": "msg",
-        "x": 725,
-        "y": 300,
-        "wires": [
-            [
-                "028a4c9c51e7eccd"
-            ]
-        ],
-        "l": false
-    },
-    {
-        "id": "79aede9e29152eb5",
-        "type": "api-current-state",
-        "z": "a5fa1fcc1b306096",
-        "g": "0d03e2a33f3a64b3",
-        "name": "",
-        "server": "176d29a.6f648d6",
-        "version": 3,
-        "outputs": 1,
-        "halt_if": "",
-        "halt_if_type": "str",
-        "halt_if_compare": "is",
-        "entity_id": "input_text.hbc_entity_m3_control_mode",
-        "state_type": "str",
-        "blockInputOverrides": true,
-        "outputProperties": [
-            {
-                "property": "payload",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entityState"
-            },
-            {
-                "property": "data",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entity"
-            },
-            {
-                "property": "topic",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "triggerId"
-            }
-        ],
-        "for": "0",
-        "forType": "num",
-        "forUnits": "minutes",
-        "override_topic": false,
-        "state_location": "payload",
-        "override_payload": "msg",
-        "entity_location": "data",
-        "override_data": "msg",
-        "x": 725,
-        "y": 340,
-        "wires": [
-            [
-                "aa7fa18db5e480cc"
-            ]
-        ],
-        "l": false
-    },
-    {
-        "id": "967320583833cbad",
-        "type": "api-current-state",
-        "z": "a5fa1fcc1b306096",
-        "g": "0d03e2a33f3a64b3",
-        "name": "",
-        "server": "176d29a.6f648d6",
-        "version": 3,
-        "outputs": 1,
-        "halt_if": "",
-        "halt_if_type": "str",
-        "halt_if_compare": "is",
-        "entity_id": "input_text.gekozen_sensor_entity_picker",
-        "state_type": "str",
-        "blockInputOverrides": true,
-        "outputProperties": [
-            {
-                "property": "payload",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entityState"
-            },
-            {
-                "property": "data",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entity"
-            },
-            {
-                "property": "topic",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "triggerId"
-            }
-        ],
-        "for": "0",
-        "forType": "num",
-        "forUnits": "minutes",
-        "override_topic": false,
-        "state_location": "payload",
-        "override_payload": "msg",
-        "entity_location": "data",
-        "override_data": "msg",
-        "x": 725,
-        "y": 500,
-        "wires": [
-            [
-                "7df02adfcd4128ea"
-            ]
-        ],
-        "l": false
-    },
-    {
-        "id": "e60f983d4392917d",
-        "type": "function",
-        "z": "a5fa1fcc1b306096",
-        "g": "937c3952d6bb2e19",
-        "name": "booleans",
-        "func": "const allEntities = RED.util.getMessageProperty(msg,\"all_entities\");\n\nlet selectOptions = [];\n\n// Loop through all entities\nfor (const [entityId, entityState] of Object.entries(allEntities)) {\n    // Filter on 'sensor' domain\n    if (entityId.startsWith('input_boolean.')) {\n\n        // Label for user: use friendly_name, or entity_id\n        const name = entityState.attributes.friendly_name || entityId;\n        const obj = {};\n        obj[name] = entityId;\n        selectOptions.push(obj); \n    }\n}\n\n// Provide the UI Dropdown node with options\nmsg.options = selectOptions;\n\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 580,
-        "y": 104,
-        "wires": [
-            [
-                "1cb5651fd3cd98f7",
-                "11b529145ce5d713",
-                "45e6ad9cded99ea2"
-            ]
-        ]
-    },
-    {
-        "id": "9d500a3c6b154999",
-        "type": "function",
-        "z": "a5fa1fcc1b306096",
-        "g": "937c3952d6bb2e19",
-        "name": "numbers",
-        "func": "const allEntities = RED.util.getMessageProperty(msg,\"all_entities\");\n\nlet selectOptions = [];\n\n// Loop through all entities\nfor (const [entityId, entityState] of Object.entries(allEntities)) {\n    // Filter on 'sensor' domain\n    if (entityId.startsWith('number.')) {\n\n        // Label for user: use friendly_name, or entity_id\n        const name = entityState.attributes.friendly_name || entityId;\n        const obj = {};\n        obj[name] = entityId;\n        selectOptions.push(obj); \n    }\n}\n\n// Provide the UI Dropdown node with options\nmsg.options = selectOptions;\n\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 580,
-        "y": 680,
-        "wires": [
-            [
-                "a71c7d4cd9e9ecb6",
-                "1a684759a42f72ef",
-                "c0114cdc7b15fba9",
-                "9a53b5725a7ae343"
-            ]
-        ]
-    },
-    {
-        "id": "1cb5651fd3cd98f7",
-        "type": "api-current-state",
-        "z": "a5fa1fcc1b306096",
-        "g": "0d03e2a33f3a64b3",
-        "name": "",
-        "server": "176d29a.6f648d6",
-        "version": 3,
-        "outputs": 1,
-        "halt_if": "",
-        "halt_if_type": "str",
-        "halt_if_compare": "is",
-        "entity_id": "input_boolean.hbc_has_battery_1",
-        "state_type": "str",
-        "blockInputOverrides": true,
-        "outputProperties": [
-            {
-                "property": "payload",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entityState"
-            },
-            {
-                "property": "data",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entity"
-            },
-            {
-                "property": "topic",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "triggerId"
-            }
-        ],
-        "for": "0",
-        "forType": "num",
-        "forUnits": "minutes",
-        "override_topic": false,
-        "state_location": "payload",
-        "override_payload": "msg",
-        "entity_location": "data",
-        "override_data": "msg",
-        "x": 725,
-        "y": 104,
-        "wires": [
-            [
-                "7867622927f0d077"
-            ]
-        ],
-        "l": false
-    },
-    {
-        "id": "a71c7d4cd9e9ecb6",
-        "type": "api-current-state",
-        "z": "a5fa1fcc1b306096",
-        "g": "0d03e2a33f3a64b3",
-        "name": "",
-        "server": "176d29a.6f648d6",
-        "version": 3,
-        "outputs": 1,
-        "halt_if": "",
-        "halt_if_type": "str",
-        "halt_if_compare": "is",
-        "entity_id": "input_text.hbc_entity_m1_max_charge_power",
-        "state_type": "str",
-        "blockInputOverrides": true,
-        "outputProperties": [
-            {
-                "property": "payload",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entityState"
-            },
-            {
-                "property": "data",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entity"
-            },
-            {
-                "property": "topic",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "triggerId"
-            }
-        ],
-        "for": "0",
-        "forType": "num",
-        "forUnits": "minutes",
-        "override_topic": false,
-        "state_location": "payload",
-        "override_payload": "msg",
-        "entity_location": "data",
-        "override_data": "msg",
-        "x": 725,
-        "y": 680,
-        "wires": [
-            [
-                "a755b33f1730e891"
-            ]
-        ],
-        "l": false
-    },
-    {
-        "id": "a755b33f1730e891",
-        "type": "ui_dropdown",
-        "z": "a5fa1fcc1b306096",
-        "g": "795071f84cc65671",
-        "name": "",
-        "label": "Battery 1 | max charge power",
-        "tooltip": "Max charging power in kWh",
-        "place": "Select option",
-        "group": "dc57595d461379a1",
-        "order": 0,
-        "width": 0,
-        "height": 0,
-        "passthru": true,
-        "multiple": false,
-        "options": [],
-        "payload": "",
-        "topic": "topic",
-        "topicType": "msg",
-        "className": "",
-        "x": 1000,
-        "y": 680,
-        "wires": [
-            [
-                "3323e8b0f6c0ee75"
-            ]
-        ]
-    },
-    {
-        "id": "1a684759a42f72ef",
-        "type": "api-current-state",
-        "z": "a5fa1fcc1b306096",
-        "g": "0d03e2a33f3a64b3",
-        "name": "",
-        "server": "176d29a.6f648d6",
-        "version": 3,
-        "outputs": 1,
-        "halt_if": "",
-        "halt_if_type": "str",
-        "halt_if_compare": "is",
-        "entity_id": "input_text.hbc_entity_m1_max_discharge_power",
-        "state_type": "str",
-        "blockInputOverrides": true,
-        "outputProperties": [
-            {
-                "property": "payload",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entityState"
-            },
-            {
-                "property": "data",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entity"
-            },
-            {
-                "property": "topic",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "triggerId"
-            }
-        ],
-        "for": "0",
-        "forType": "num",
-        "forUnits": "minutes",
-        "override_topic": false,
-        "state_location": "payload",
-        "override_payload": "msg",
-        "entity_location": "data",
-        "override_data": "msg",
-        "x": 725,
-        "y": 720,
-        "wires": [
-            [
-                "14124387949b0fee"
-            ]
-        ],
-        "l": false
-    },
-    {
-        "id": "14124387949b0fee",
-        "type": "ui_dropdown",
-        "z": "a5fa1fcc1b306096",
-        "g": "795071f84cc65671",
-        "name": "",
-        "label": "Battery 1 | max discharge power",
-        "tooltip": "Max discharging power in kWh",
-        "place": "Select option",
-        "group": "dc57595d461379a1",
-        "order": 0,
-        "width": 0,
-        "height": 0,
-        "passthru": true,
-        "multiple": false,
-        "options": [],
-        "payload": "",
-        "topic": "topic",
-        "topicType": "msg",
-        "className": "",
-        "x": 1010,
-        "y": 720,
-        "wires": [
-            [
-                "3323e8b0f6c0ee75"
-            ]
-        ]
-    },
-    {
-        "id": "7867622927f0d077",
-        "type": "ui_switch",
-        "z": "a5fa1fcc1b306096",
-        "g": "795071f84cc65671",
-        "name": "Battery 1 | enabled",
-        "label": "Enable",
-        "tooltip": "Enable the use of battery #1",
-        "group": "dc57595d461379a1",
-        "order": 5,
-        "width": 0,
-        "height": 0,
-        "passthru": true,
-        "decouple": "false",
-        "topic": "topic",
-        "topicType": "msg",
-        "style": "",
-        "onvalue": "true",
-        "onvalueType": "bool",
-        "onicon": "",
-        "oncolor": "",
-        "offvalue": "false",
-        "offvalueType": "bool",
-        "officon": "",
-        "offcolor": "",
-        "animate": false,
-        "className": "",
-        "x": 970,
-        "y": 104,
-        "wires": [
-            [
-                "c2f36f14e0eb1058"
-            ]
-        ]
-    },
-    {
-        "id": "ebb77d5a4bb73b23",
-        "type": "ui_dropdown",
-        "z": "a5fa1fcc1b306096",
-        "g": "795071f84cc65671",
-        "name": "",
-        "label": "Battery 1 | State of Charge (SoC)",
-        "tooltip": "e.g. sensor.marstek_m1_battery_state_of_charge",
-        "place": "Select option",
-        "group": "dc57595d461379a1",
-        "order": 0,
-        "width": 0,
-        "height": 0,
-        "passthru": true,
-        "multiple": false,
-        "options": [],
-        "payload": "",
-        "topic": "topic",
-        "topicType": "msg",
-        "className": "",
-        "x": 1020,
-        "y": 540,
-        "wires": [
-            [
-                "3323e8b0f6c0ee75"
-            ]
-        ]
-    },
-    {
-        "id": "892e1829e04b12de",
-        "type": "api-current-state",
-        "z": "a5fa1fcc1b306096",
-        "g": "0d03e2a33f3a64b3",
-        "name": "",
-        "server": "176d29a.6f648d6",
-        "version": 3,
-        "outputs": 1,
-        "halt_if": "",
-        "halt_if_type": "str",
-        "halt_if_compare": "is",
-        "entity_id": "input_text.hbc_entity_m1_battery_state_of_charge",
-        "state_type": "str",
-        "blockInputOverrides": true,
-        "outputProperties": [
-            {
-                "property": "payload",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entityState"
-            },
-            {
-                "property": "data",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entity"
-            },
-            {
-                "property": "topic",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "triggerId"
-            }
-        ],
-        "for": "0",
-        "forType": "num",
-        "forUnits": "minutes",
-        "override_topic": false,
-        "state_location": "payload",
-        "override_payload": "msg",
-        "entity_location": "data",
-        "override_data": "msg",
-        "x": 725,
-        "y": 540,
-        "wires": [
-            [
-                "ebb77d5a4bb73b23"
-            ]
-        ],
-        "l": false
-    },
-    {
-        "id": "c0114cdc7b15fba9",
-        "type": "api-current-state",
-        "z": "a5fa1fcc1b306096",
-        "g": "0d03e2a33f3a64b3",
-        "name": "",
-        "server": "176d29a.6f648d6",
-        "version": 3,
-        "outputs": 1,
-        "halt_if": "",
-        "halt_if_type": "str",
-        "halt_if_compare": "is",
-        "entity_id": "input_text.hbc_entity_m1_charging_cutoff_capacity",
-        "state_type": "str",
-        "blockInputOverrides": true,
-        "outputProperties": [
-            {
-                "property": "payload",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entityState"
-            },
-            {
-                "property": "data",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entity"
-            },
-            {
-                "property": "topic",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "triggerId"
-            }
-        ],
-        "for": "0",
-        "forType": "num",
-        "forUnits": "minutes",
-        "override_topic": false,
-        "state_location": "payload",
-        "override_payload": "msg",
-        "entity_location": "data",
-        "override_data": "msg",
-        "x": 725,
-        "y": 780,
-        "wires": [
-            [
-                "b39feae3a058ace5"
-            ]
-        ],
-        "l": false
-    },
-    {
-        "id": "b39feae3a058ace5",
-        "type": "ui_dropdown",
-        "z": "a5fa1fcc1b306096",
-        "g": "795071f84cc65671",
-        "name": "",
-        "label": "Battery 1 | Charging cutoff capacity",
-        "tooltip": "e.g. number.marstek_m1_charging_cutoff_capacity",
-        "place": "Select option",
-        "group": "dc57595d461379a1",
-        "order": 0,
-        "width": 0,
-        "height": 0,
-        "passthru": true,
-        "multiple": false,
-        "options": [],
-        "payload": "",
-        "topic": "topic",
-        "topicType": "msg",
-        "className": "",
-        "x": 1020,
-        "y": 780,
-        "wires": [
-            [
-                "3323e8b0f6c0ee75"
-            ]
-        ]
-    },
-    {
-        "id": "9a53b5725a7ae343",
-        "type": "api-current-state",
-        "z": "a5fa1fcc1b306096",
-        "g": "0d03e2a33f3a64b3",
-        "name": "",
-        "server": "176d29a.6f648d6",
-        "version": 3,
-        "outputs": 1,
-        "halt_if": "",
-        "halt_if_type": "str",
-        "halt_if_compare": "is",
-        "entity_id": "input_text.hbc_entity_m1_discharging_cutoff_capacity",
-        "state_type": "str",
-        "blockInputOverrides": true,
-        "outputProperties": [
-            {
-                "property": "payload",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entityState"
-            },
-            {
-                "property": "data",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entity"
-            },
-            {
-                "property": "topic",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "triggerId"
-            }
-        ],
-        "for": "0",
-        "forType": "num",
-        "forUnits": "minutes",
-        "override_topic": false,
-        "state_location": "payload",
-        "override_payload": "msg",
-        "entity_location": "data",
-        "override_data": "msg",
-        "x": 725,
-        "y": 820,
-        "wires": [
-            [
-                "1f8079b3d993b6ff"
-            ]
-        ],
-        "l": false
-    },
-    {
-        "id": "1f8079b3d993b6ff",
-        "type": "ui_dropdown",
-        "z": "a5fa1fcc1b306096",
-        "g": "795071f84cc65671",
-        "name": "",
-        "label": "Battery 1 | Disharging cutoff capacity",
-        "tooltip": "e.g. number.marstek_m1_discharging_cutoff_capacity",
-        "place": "Select option",
-        "group": "dc57595d461379a1",
-        "order": 0,
-        "width": 0,
-        "height": 0,
-        "passthru": true,
-        "multiple": false,
-        "options": [],
-        "payload": "",
-        "topic": "topic",
-        "topicType": "msg",
-        "className": "",
-        "x": 1030,
-        "y": 820,
-        "wires": [
-            [
-                "3323e8b0f6c0ee75"
-            ]
-        ]
-    },
-    {
-        "id": "15d0a55aad6896dc",
-        "type": "api-current-state",
-        "z": "a5fa1fcc1b306096",
-        "g": "0d03e2a33f3a64b3",
-        "name": "",
-        "server": "176d29a.6f648d6",
-        "version": 3,
-        "outputs": 1,
-        "halt_if": "",
-        "halt_if_type": "str",
-        "halt_if_compare": "is",
-        "entity_id": "input_text.hbc_entity_p1_power",
-        "state_type": "str",
-        "blockInputOverrides": true,
-        "outputProperties": [
-            {
-                "property": "payload",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entityState"
-            },
-            {
-                "property": "data",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entity"
-            },
-            {
-                "property": "topic",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "triggerId"
-            }
-        ],
-        "for": "0",
-        "forType": "num",
-        "forUnits": "minutes",
-        "override_topic": false,
-        "state_location": "payload",
-        "override_payload": "msg",
-        "entity_location": "data",
-        "override_data": "msg",
-        "x": 725,
-        "y": 460,
-        "wires": [
-            [
-                "3c2735a64344066e"
-            ]
-        ],
-        "l": false
-    },
-    {
-        "id": "3c2735a64344066e",
-        "type": "ui_dropdown",
-        "z": "a5fa1fcc1b306096",
-        "g": "795071f84cc65671",
-        "name": "",
-        "label": "P1 meter power",
-        "tooltip": "See: /config/template_sensors/template_sensor_house_battery_control.yaml",
-        "place": "Select option",
-        "group": "9bfeb0b645386875",
-        "order": 0,
-        "width": 0,
-        "height": 0,
-        "passthru": true,
-        "multiple": false,
-        "options": [],
-        "payload": "",
-        "topic": "topic",
-        "topicType": "msg",
-        "className": "",
-        "x": 960,
-        "y": 460,
-        "wires": [
-            [
-                "3323e8b0f6c0ee75"
-            ]
-        ]
-    },
-    {
-        "id": "a0c32b752bed188a",
-        "type": "api-current-state",
-        "z": "a5fa1fcc1b306096",
-        "g": "0d03e2a33f3a64b3",
-        "name": "",
-        "server": "176d29a.6f648d6",
-        "version": 3,
-        "outputs": 1,
-        "halt_if": "",
-        "halt_if_type": "str",
-        "halt_if_compare": "is",
-        "entity_id": "input_text.hbc_entity_m1_inverter_state",
-        "state_type": "str",
-        "blockInputOverrides": true,
-        "outputProperties": [
-            {
-                "property": "payload",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entityState"
-            },
-            {
-                "property": "data",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entity"
-            },
-            {
-                "property": "topic",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "triggerId"
-            }
-        ],
-        "for": "0",
-        "forType": "num",
-        "forUnits": "minutes",
-        "override_topic": false,
-        "state_location": "payload",
-        "override_payload": "msg",
-        "entity_location": "data",
-        "override_data": "msg",
-        "x": 725,
-        "y": 576,
-        "wires": [
-            [
-                "77426ad1f331d3f8"
-            ]
-        ],
-        "l": false
-    },
-    {
-        "id": "77426ad1f331d3f8",
-        "type": "ui_dropdown",
-        "z": "a5fa1fcc1b306096",
-        "g": "795071f84cc65671",
-        "name": "",
-        "label": "Battery 1 | Inverter state",
-        "tooltip": "e.g. sensor.marstek_m1_inverter_state",
-        "place": "Select option",
-        "group": "dc57595d461379a1",
-        "order": 0,
-        "width": 0,
-        "height": 0,
-        "passthru": true,
-        "multiple": false,
-        "options": [],
-        "payload": "",
-        "topic": "topic",
-        "topicType": "msg",
-        "className": "",
-        "x": 990,
-        "y": 576,
-        "wires": [
-            [
-                "3323e8b0f6c0ee75"
-            ]
-        ]
-    },
-    {
-        "id": "521c90d39990183f",
-        "type": "api-current-state",
-        "z": "a5fa1fcc1b306096",
-        "g": "0d03e2a33f3a64b3",
-        "name": "",
-        "server": "176d29a.6f648d6",
-        "version": 3,
-        "outputs": 1,
-        "halt_if": "",
-        "halt_if_type": "str",
-        "halt_if_compare": "is",
-        "entity_id": "input_text.hbc_entity_m1_battery_remaining_capacity",
-        "state_type": "str",
-        "blockInputOverrides": true,
-        "outputProperties": [
-            {
-                "property": "payload",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entityState"
-            },
-            {
-                "property": "data",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entity"
-            },
-            {
-                "property": "topic",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "triggerId"
-            }
-        ],
-        "for": "0",
-        "forType": "num",
-        "forUnits": "minutes",
-        "override_topic": false,
-        "state_location": "payload",
-        "override_payload": "msg",
-        "entity_location": "data",
-        "override_data": "msg",
-        "x": 725,
-        "y": 616,
-        "wires": [
-            [
-                "af5a6883b065a9fc"
-            ]
-        ],
-        "l": false
-    },
-    {
-        "id": "af5a6883b065a9fc",
-        "type": "ui_dropdown",
-        "z": "a5fa1fcc1b306096",
-        "g": "795071f84cc65671",
-        "name": "",
-        "label": "Battery 1 | Remaining capacity (kWh)",
-        "tooltip": "e.g. sensor.marstek_m1_battery_remaining_capacity",
-        "place": "Select option",
-        "group": "dc57595d461379a1",
-        "order": 0,
-        "width": 0,
-        "height": 0,
-        "passthru": true,
-        "multiple": false,
-        "options": [],
-        "payload": "",
-        "topic": "topic",
-        "topicType": "msg",
-        "className": "",
-        "x": 1030,
-        "y": 616,
-        "wires": [
-            [
-                "3323e8b0f6c0ee75"
-            ]
-        ]
-    },
-    {
-        "id": "11b529145ce5d713",
-        "type": "api-current-state",
-        "z": "a5fa1fcc1b306096",
-        "g": "0d03e2a33f3a64b3",
-        "name": "",
-        "server": "176d29a.6f648d6",
-        "version": 3,
-        "outputs": 1,
-        "halt_if": "",
-        "halt_if_type": "str",
-        "halt_if_compare": "is",
-        "entity_id": "input_boolean.hbc_has_battery_2",
-        "state_type": "str",
-        "blockInputOverrides": true,
-        "outputProperties": [
-            {
-                "property": "payload",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entityState"
-            },
-            {
-                "property": "data",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entity"
-            },
-            {
-                "property": "topic",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "triggerId"
-            }
-        ],
-        "for": "0",
-        "forType": "num",
-        "forUnits": "minutes",
-        "override_topic": false,
-        "state_location": "payload",
-        "override_payload": "msg",
-        "entity_location": "data",
-        "override_data": "msg",
-        "x": 725,
-        "y": 140,
-        "wires": [
-            [
-                "4d3e69a2b3b4e1bd"
-            ]
-        ],
-        "l": false
-    },
-    {
-        "id": "45e6ad9cded99ea2",
-        "type": "api-current-state",
-        "z": "a5fa1fcc1b306096",
-        "g": "0d03e2a33f3a64b3",
-        "name": "",
-        "server": "176d29a.6f648d6",
-        "version": 3,
-        "outputs": 1,
-        "halt_if": "",
-        "halt_if_type": "str",
-        "halt_if_compare": "is",
-        "entity_id": "input_boolean.hbc_has_battery_3",
-        "state_type": "str",
-        "blockInputOverrides": true,
-        "outputProperties": [
-            {
-                "property": "payload",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entityState"
-            },
-            {
-                "property": "data",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "entity"
-            },
-            {
-                "property": "topic",
-                "propertyType": "msg",
-                "value": "",
-                "valueType": "triggerId"
-            }
-        ],
-        "for": "0",
-        "forType": "num",
-        "forUnits": "minutes",
-        "override_topic": false,
-        "state_location": "payload",
-        "override_payload": "msg",
-        "entity_location": "data",
-        "override_data": "msg",
-        "x": 725,
-        "y": 180,
-        "wires": [
-            [
-                "8d2077410a644d6e"
-            ]
-        ],
-        "l": false
-    },
-    {
-        "id": "4d3e69a2b3b4e1bd",
-        "type": "ui_switch",
-        "z": "a5fa1fcc1b306096",
-        "g": "795071f84cc65671",
-        "name": "Battery 2 | enabled",
-        "label": "Enable",
-        "tooltip": "Enable the use of battery #2",
-        "group": "54991681ca09e29d",
-        "order": 5,
-        "width": 0,
-        "height": 0,
-        "passthru": true,
-        "decouple": "false",
-        "topic": "topic",
-        "topicType": "msg",
-        "style": "",
-        "onvalue": "true",
-        "onvalueType": "bool",
-        "onicon": "",
-        "oncolor": "",
-        "offvalue": "false",
-        "offvalueType": "bool",
-        "officon": "",
-        "offcolor": "",
-        "animate": false,
-        "className": "",
-        "x": 970,
-        "y": 140,
-        "wires": [
-            [
-                "c2f36f14e0eb1058"
-            ]
-        ]
-    },
-    {
-        "id": "8d2077410a644d6e",
-        "type": "ui_switch",
-        "z": "a5fa1fcc1b306096",
-        "g": "795071f84cc65671",
-        "name": "Battery 3 | enabled",
-        "label": "Enable",
-        "tooltip": "Enable the use of battery #3",
-        "group": "ab91aa3e54c948ec",
-        "order": 5,
-        "width": 0,
-        "height": 0,
-        "passthru": true,
-        "decouple": "false",
-        "topic": "topic",
-        "topicType": "msg",
-        "style": "",
-        "onvalue": "true",
-        "onvalueType": "bool",
-        "onicon": "",
-        "oncolor": "",
-        "offvalue": "false",
-        "offvalueType": "bool",
-        "officon": "",
-        "offcolor": "",
-        "animate": false,
-        "className": "",
-        "x": 970,
-        "y": 180,
-        "wires": [
-            [
-                "c2f36f14e0eb1058"
-            ]
-        ]
-    },
-    {
-        "id": "c2f36f14e0eb1058",
-        "type": "function",
-        "z": "a5fa1fcc1b306096",
-        "g": "e9025250f91b9eb0",
-        "name": "set input_boolean",
-        "func": "const value = msg.payload;\nconst target = msg.topic;\n\nmsg.payload = {\n    \"action\": value?\"input_boolean.turn_on\":\"input_boolean.turn_off\",\n    \"target\": {\n        \"entity_id\": [target]\n    },\n    \"data\": {}\n}\n\n\nreturn msg;",
-        "outputs": 1,
-        "timeout": 0,
-        "noerr": 0,
-        "initialize": "",
-        "finalize": "",
-        "libs": [],
-        "x": 1350,
-        "y": 100,
-        "wires": [
-            [
-                "edf81a129949f7af"
-            ]
-        ]
-    },
-    {
-        "id": "00bc695e6e14ac68",
-        "type": "api-current-state",
-        "z": "0175d4a664d6a895",
-        "g": "953fd66d6e9a5104",
+        "z": "90ba722d19d180d0",
+        "g": "68c1ff5282e98cfc",
         "name": "Your battery count",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -5960,15 +2012,15 @@
         "y": 60,
         "wires": [
             [
-                "3e234ef1ac1876ef"
+                "cca00e713027d587"
             ]
         ]
     },
     {
-        "id": "ffd2ae9d0c0567db",
+        "id": "5c0e52bab7ca452a",
         "type": "function",
-        "z": "0175d4a664d6a895",
-        "g": "850a4db192a92f5c",
+        "z": "90ba722d19d180d0",
+        "g": "4c9715590340f74a",
         "name": "Set RS485 and Work Modes",
         "func": "// array for output \nlet outputArray = [];\n\n// battery to target\nconst target = `marstek_m${msg.battery_index}`;\n\n// Set | work mode\nconst workModeAction = {\n    \"action\": \"select.select_option\",\n    \"target\": {\n        \"entity_id\": [`select.${target}_user_work_mode`]\n    },\n    \"data\": {\n         \"option\": String(msg.work_mode)\n    }\n};\n// Add to output array. Set null for no action.\noutputArray.push(msg.work_mode ? { payload: workModeAction, topic:\"user_work_mode\"}: null);\n\n// Set | rs485\nconst rs485Action = {\n    \"action\": \"select.select_option\",\n    \"target\": {\n        \"entity_id\": [`select.${target}_rs485_control_mode`]\n    },\n    \"data\": {\n         \"option\": String(msg.rs485)\n    }\n};\n// Add to output array. Set null for no action.\noutputArray.push(msg.rs485 ? { payload: rs485Action, topic: \"rs485_control_mode\" } : null);\n\n// Store calls in msg to allow checking of loop results\nmsg.loop_result = { target, workModeAction, rs485Action };\n\n// Return msg as third output\noutputArray.push(msg);\n\n// Outputs\nreturn outputArray;",
         "outputs": 3,
@@ -5981,21 +2033,21 @@
         "y": 180,
         "wires": [
             [
-                "d334843b10486744"
+                "ee97315d36787b6a"
             ],
             [
-                "871d86a303aff3a2"
+                "675f7035505da486"
             ],
             [
-                "51569e358b758d85"
+                "1963c871dda0c6cb"
             ]
         ]
     },
     {
-        "id": "3e234ef1ac1876ef",
+        "id": "cca00e713027d587",
         "type": "function",
-        "z": "0175d4a664d6a895",
-        "g": "953fd66d6e9a5104",
+        "z": "90ba722d19d180d0",
+        "g": "68c1ff5282e98cfc",
         "name": "Loop start",
         "func": "// loop through the number of batteries set by the user\nmsg.battery_index = 1; // base-1\n\n// configurables\nlet workMode = null; // manual, anti-feed, ai, null = don't set or alter this setting\nlet rs485 = null;  // enable, disable, null = don't set or alter this setting\n\n// mode select\nswitch (msg.marstek_master_battery_mode) {\n    case \"Manual control\":\n        workMode = \"manual\";\n        rs485 = \"disable\";\n        break;\n    case \"Marstek control\":\n        // the user should select a work mode via the Marstek App or via select.marstek_mX_user_work_mode\n        rs485 = \"disable\";\n        break;\n    case \"Full control\":\n        rs485 = \"enable\";\n        break;\n    default:\n        node.status({fill:\"red\",shape:\"ring\",text:`Unhandled mode: ${msg.marstek_master_battery_mode}`});\n        return null; // stop flow\n}\n\n// Continue\nmsg.work_mode = workMode;\nmsg.rs485 = rs485;\nreturn msg;",
         "outputs": 1,
@@ -6008,15 +2060,15 @@
         "y": 180,
         "wires": [
             [
-                "ffd2ae9d0c0567db"
+                "5c0e52bab7ca452a"
             ]
         ]
     },
     {
-        "id": "51569e358b758d85",
+        "id": "1963c871dda0c6cb",
         "type": "function",
-        "z": "0175d4a664d6a895",
-        "g": "850a4db192a92f5c",
+        "z": "90ba722d19d180d0",
+        "g": "4c9715590340f74a",
         "name": "Loop step",
         "func": "// Step index down\nmsg.battery_index += 1;\n\n// Continue\nreturn msg;",
         "outputs": 1,
@@ -6029,16 +2081,16 @@
         "y": 240,
         "wires": [
             [
-                "ab85be4609428733",
-                "30cdb945f14cd2de"
+                "ec78c1a734f54aa2",
+                "aab0a177eb87ddf5"
             ]
         ]
     },
     {
-        "id": "ab85be4609428733",
+        "id": "ec78c1a734f54aa2",
         "type": "switch",
-        "z": "0175d4a664d6a895",
-        "g": "850a4db192a92f5c",
+        "z": "90ba722d19d180d0",
+        "g": "4c9715590340f74a",
         "name": "Loop until",
         "property": "battery_index",
         "propertyType": "msg",
@@ -6059,18 +2111,18 @@
         "y": 240,
         "wires": [
             [
-                "ffd2ae9d0c0567db"
+                "5c0e52bab7ca452a"
             ],
             [
-                "c29838d388949d73"
+                "5a66d9b14e186590"
             ]
         ]
     },
     {
-        "id": "d334843b10486744",
+        "id": "ee97315d36787b6a",
         "type": "api-call-service",
-        "z": "0175d4a664d6a895",
-        "g": "850a4db192a92f5c",
+        "z": "90ba722d19d180d0",
+        "g": "4c9715590340f74a",
         "name": "Set work mode",
         "server": "176d29a.6f648d6",
         "version": 7,
@@ -6097,10 +2149,10 @@
         ]
     },
     {
-        "id": "871d86a303aff3a2",
+        "id": "675f7035505da486",
         "type": "api-call-service",
-        "z": "0175d4a664d6a895",
-        "g": "850a4db192a92f5c",
+        "z": "90ba722d19d180d0",
+        "g": "4c9715590340f74a",
         "name": "Set RS485",
         "server": "176d29a.6f648d6",
         "version": 7,
@@ -6127,10 +2179,10 @@
         ]
     },
     {
-        "id": "30cdb945f14cd2de",
+        "id": "aab0a177eb87ddf5",
         "type": "debug",
-        "z": "0175d4a664d6a895",
-        "g": "850a4db192a92f5c",
+        "z": "90ba722d19d180d0",
+        "g": "4c9715590340f74a",
         "name": "Loop result",
         "active": false,
         "tosidebar": true,
@@ -6145,10 +2197,10 @@
         "wires": []
     },
     {
-        "id": "c29838d388949d73",
+        "id": "5a66d9b14e186590",
         "type": "debug",
-        "z": "0175d4a664d6a895",
-        "g": "953fd66d6e9a5104",
+        "z": "90ba722d19d180d0",
+        "g": "68c1ff5282e98cfc",
         "name": "Done",
         "active": true,
         "tosidebar": false,
@@ -6163,10 +2215,10 @@
         "wires": []
     },
     {
-        "id": "8f09b2ae8c025fcd",
+        "id": "364d5ef5318739ef",
         "type": "server-state-changed",
-        "z": "0175d4a664d6a895",
-        "g": "953fd66d6e9a5104",
+        "z": "90ba722d19d180d0",
+        "g": "68c1ff5282e98cfc",
         "name": "Master control mode",
         "server": "176d29a.6f648d6",
         "version": 6,
@@ -6223,15 +2275,15 @@
         "y": 60,
         "wires": [
             [
-                "00bc695e6e14ac68"
+                "77e00747c15d33d8"
             ]
         ]
     },
     {
-        "id": "ab11a2efc339a986",
+        "id": "0a5681c3e62ca4ac",
         "type": "server-state-changed",
-        "z": "372bd960bc6674b6",
-        "g": "77e8d4e34d78e299",
+        "z": "3d30ac5470c32b57",
+        "g": "6fd1d2a9a49cdcf4",
         "name": "PID preset selected",
         "server": "176d29a.6f648d6",
         "version": 6,
@@ -6282,15 +2334,15 @@
         "y": 100,
         "wires": [
             [
-                "2c085b75d84e29dd"
+                "60bdd7beed2695a3"
             ]
         ]
     },
     {
-        "id": "55f9708f59d9a023",
+        "id": "df1709d77a25c3be",
         "type": "api-call-service",
-        "z": "372bd960bc6674b6",
-        "g": "77e8d4e34d78e299",
+        "z": "3d30ac5470c32b57",
+        "g": "6fd1d2a9a49cdcf4",
         "name": "Kp",
         "server": "176d29a.6f648d6",
         "version": 7,
@@ -6319,10 +2371,10 @@
         ]
     },
     {
-        "id": "5920c11bd429721a",
+        "id": "efbb4e7edd2bbc0e",
         "type": "api-call-service",
-        "z": "372bd960bc6674b6",
-        "g": "77e8d4e34d78e299",
+        "z": "3d30ac5470c32b57",
+        "g": "6fd1d2a9a49cdcf4",
         "name": "Ki",
         "server": "176d29a.6f648d6",
         "version": 7,
@@ -6351,10 +2403,10 @@
         ]
     },
     {
-        "id": "f47ec641a00398ae",
+        "id": "ec0d3dc0a6333191",
         "type": "api-call-service",
-        "z": "372bd960bc6674b6",
-        "g": "77e8d4e34d78e299",
+        "z": "3d30ac5470c32b57",
+        "g": "6fd1d2a9a49cdcf4",
         "name": "Kd",
         "server": "176d29a.6f648d6",
         "version": 7,
@@ -6383,10 +2435,10 @@
         ]
     },
     {
-        "id": "2c085b75d84e29dd",
+        "id": "60bdd7beed2695a3",
         "type": "function",
-        "z": "372bd960bc6674b6",
-        "g": "77e8d4e34d78e299",
+        "z": "3d30ac5470c32b57",
+        "g": "6fd1d2a9a49cdcf4",
         "name": "Presets",
         "func": "// See: house_battery_control.yaml > input_select: > house_battery_control_pid_presets\nconst preset = RED.util.getMessageProperty(msg,\"payload\");\nnode.status({fill:\"green\",shape:\"dot\",text:`${preset}`});\n\n\n// Default values\nlet Kp = 0; // Proportional gain\nlet Ki = 0; // Integral gain\nlet Kd = 0; // Differentiating gain\nlet Si = 0; // % Input smoothing (a Low pass moving average filter)\nlet So = 0; // % Output smoothing (a Low pass moving average filter)\n\nswitch (preset) {\n    // For people who have unstable systems with every other preset\n    case \"Very safe\":\n        Kp = 0.1;\n        Ki = 0.1;\n        Si = 0; // without Kd, this is preferred to be zero.\n        So = 10; // %\n        break;\n    // Good starting point for most\n    case \"Safe\":\n        Kp = 0.3;\n        Ki = 0.3;\n        Kd = 0.1;\n        Si = 20; // %\n        So = 0; // %\n        break;\n    // Gitcodebob's October 2025 settings for 3.2kWp PV and 5kW battery transformer power\n    case \"Regular\":\n        Kp = 0.3;\n        Ki = 0.4;\n        Kd = 0.8;\n        Si = 50; // % This high amount of filtering allows the stronger Kd\n        So = 10; // %\n        break;\n    default:\n        // Don't change values\n        return null;\n}\n\n// Prepare for three outputs\nreturn [\n    { \"payload\": Kp },\n    { \"payload\": Ki },\n    { \"payload\": Kd },\n    { \"payload\": Si },\n    { \"payload\": So }\n];",
         "outputs": 5,
@@ -6399,27 +2451,27 @@
         "y": 100,
         "wires": [
             [
-                "55f9708f59d9a023"
+                "df1709d77a25c3be"
             ],
             [
-                "5920c11bd429721a"
+                "efbb4e7edd2bbc0e"
             ],
             [
-                "f47ec641a00398ae"
+                "ec0d3dc0a6333191"
             ],
             [
-                "37ddfce1de5fed7e"
+                "d56baae3fc3002ca"
             ],
             [
-                "37faa6d3c80dc619"
+                "e4758c2f74c708fb"
             ]
         ]
     },
     {
-        "id": "37ddfce1de5fed7e",
+        "id": "d56baae3fc3002ca",
         "type": "api-call-service",
-        "z": "372bd960bc6674b6",
-        "g": "77e8d4e34d78e299",
+        "z": "3d30ac5470c32b57",
+        "g": "6fd1d2a9a49cdcf4",
         "name": "Input Smooth",
         "server": "176d29a.6f648d6",
         "version": 7,
@@ -6448,10 +2500,10 @@
         ]
     },
     {
-        "id": "37faa6d3c80dc619",
+        "id": "e4758c2f74c708fb",
         "type": "api-call-service",
-        "z": "372bd960bc6674b6",
-        "g": "77e8d4e34d78e299",
+        "z": "3d30ac5470c32b57",
+        "g": "6fd1d2a9a49cdcf4",
         "name": "Output Smoothing",
         "server": "176d29a.6f648d6",
         "version": 7,
@@ -6480,10 +2532,10 @@
         ]
     },
     {
-        "id": "f8c504d6de9e8838",
+        "id": "4c318cf475da639a",
         "type": "server-state-changed",
-        "z": "48ac861af1dcedb4",
-        "g": "b3bb650844db8d91",
+        "z": "23a4e27f08db4d94",
+        "g": "1c746e23f2ce2ca7",
         "name": "P1 meter",
         "server": "176d29a.6f648d6",
         "version": 6,
@@ -6546,15 +2598,15 @@
         "y": 60,
         "wires": [
             [
-                "1535bb0687ee8cf4"
+                "6523d6dc4284f77b"
             ]
         ]
     },
     {
-        "id": "1535bb0687ee8cf4",
+        "id": "6523d6dc4284f77b",
         "type": "api-current-state",
-        "z": "48ac861af1dcedb4",
-        "g": "b3bb650844db8d91",
+        "z": "23a4e27f08db4d94",
+        "g": "1c746e23f2ce2ca7",
         "name": "Master Control Mode",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -6597,15 +2649,15 @@
         "y": 60,
         "wires": [
             [
-                "b3d7ff14ccf5bde0"
+                "5a4559ef501fad73"
             ]
         ]
     },
     {
-        "id": "b3d7ff14ccf5bde0",
+        "id": "5a4559ef501fad73",
         "type": "switch",
-        "z": "48ac861af1dcedb4",
-        "g": "b3bb650844db8d91",
+        "z": "23a4e27f08db4d94",
+        "g": "1c746e23f2ce2ca7",
         "name": "when in \"Full Control\" mode",
         "property": "payload",
         "propertyType": "msg",
@@ -6623,15 +2675,15 @@
         "y": 60,
         "wires": [
             [
-                "c5a35a3e13c3974a"
+                "622625722f27fd1d"
             ]
         ]
     },
     {
-        "id": "654b3d36a54e6150",
+        "id": "b47e86acdadefdf0",
         "type": "function",
-        "z": "48ac861af1dcedb4",
-        "g": "9b07562053189234",
+        "z": "23a4e27f08db4d94",
+        "g": "d0359c3b08e2f524",
         "name": "Strategy selection",
         "func": "// Logger\nconst logger = global.get(\"logger\");\n\n// INFLOW\nlet strategy = flow.get(\"house_battery_strategy\");\n\n// Configure msg.strategy object\nRED.util.setMessageProperty(msg,\"strategy.selected\",strategy,true); // by user\nRED.util.setMessageProperty(msg,\"strategy.trace\",[],true); // init trace: which flows have been executed\n\n// stop on error\nif(msg.batteries === undefined) {\n    logger(this, \"Battery configuration undefined\", \"error\");\n    return null;\n}\nif(strategy === undefined) {\n    logger(this, \"Battery strategy undefined\", \"error\");\n    return null;\n}\n\n// Default | select target flow based on the input_select `house_battery_strategy`\nmsg.target = `${strategy}`;\n\n// full stop trigger overrules ALL selected strategies\nconst stopTrigger = RED.util.getMessageProperty(msg,\"full_stop_trigger\");\nif(stopTrigger == \"on\" || stopTrigger === true || stopTrigger === 1) {\n    msg.target = 'Full stop';\n    // Explain\n    logger(this, `**Full Stop** strategy selected, due to (EV) stop trigger: '${stopTrigger}'`);\n}\n\n// add execution marker\nRED.util.setMessageProperty(msg,\"strategy.execution_start\",Date.now()); // when do we start executing the selected strategy\n\n// OUTPUT\nnode.status({fill:\"grey\",shape:\"dot\",text:msg.target});\nreturn msg;",
         "outputs": 1,
@@ -6644,16 +2696,16 @@
         "y": 1140,
         "wires": [
             [
-                "3fbac4f34c6d43a5",
-                "7c0c97a87c235885"
+                "adb89d0bfdd1a012",
+                "04ab02f28044ef0c"
             ]
         ]
     },
     {
-        "id": "7c0c97a87c235885",
+        "id": "04ab02f28044ef0c",
         "type": "link call",
-        "z": "48ac861af1dcedb4",
-        "g": "9b07562053189234",
+        "z": "23a4e27f08db4d94",
+        "g": "d0359c3b08e2f524",
         "name": "Call \"Link in\" node",
         "links": [],
         "linkType": "dynamic",
@@ -6662,16 +2714,16 @@
         "y": 1180,
         "wires": [
             [
-                "e34805b6dc851f1c",
-                "a4c887d6a2ce98ec"
+                "a24f03a0b601c08e",
+                "925e44f5181079a0"
             ]
         ]
     },
     {
-        "id": "3fbac4f34c6d43a5",
+        "id": "adb89d0bfdd1a012",
         "type": "debug",
-        "z": "48ac861af1dcedb4",
-        "g": "9b07562053189234",
+        "z": "23a4e27f08db4d94",
+        "g": "d0359c3b08e2f524",
         "name": "Input msg",
         "active": false,
         "tosidebar": true,
@@ -6686,10 +2738,10 @@
         "wires": []
     },
     {
-        "id": "e34805b6dc851f1c",
+        "id": "a24f03a0b601c08e",
         "type": "debug",
-        "z": "48ac861af1dcedb4",
-        "g": "9b07562053189234",
+        "z": "23a4e27f08db4d94",
+        "g": "d0359c3b08e2f524",
         "name": "Returned msg",
         "active": false,
         "tosidebar": true,
@@ -6704,10 +2756,10 @@
         "wires": []
     },
     {
-        "id": "a4c887d6a2ce98ec",
+        "id": "925e44f5181079a0",
         "type": "function",
-        "z": "48ac861af1dcedb4",
-        "g": "9b07562053189234",
+        "z": "23a4e27f08db4d94",
+        "g": "d0359c3b08e2f524",
         "name": "Strategy evaluation",
         "func": "// add execution marker\nlet execution_end = Date.now();\nRED.util.setMessageProperty(msg, \"strategy.execution_end\", execution_end);\n\n// retrieve execution markers\nlet execution_start = RED.util.getMessageProperty(msg,\"strategy.execution_start\");\n\n// report execution time\nif (execution_start !== undefined && execution_end !== undefined) {\n    // exec time\n    let execution_time = (execution_end - execution_start) / 1000; // seconds\n    // report\n    if (execution_time <= 0) node.status({ fill: \"red\", shape: \"dot\", text: `negative or zero timing` });\n    if (execution_time > 0) node.status({ fill: \"green\", shape: \"dot\", text: `${execution_time} sec`});\n    if (execution_time >= 0.7) node.status({ fill: \"yellow\", shape: \"dot\", text: `${execution_time} sec` });\n    if (execution_time >= 1) node.status({ fill: \"red\", shape: \"dot\", text: `${execution_time} sec` });\n\n} else {\n    node.status({fill:\"grey\",shape:\"dot\",text:\"timing error\"});\n}\n\nreturn msg;",
         "outputs": 1,
@@ -6720,17 +2772,17 @@
         "y": 1220,
         "wires": [
             [
-                "69873d54a2788a83",
-                "4177e91aeda624f2",
-                "85a54c063f523e6a"
+                "6c6f92bd8ea7eb6d",
+                "c48cbfe9a99734a4",
+                "b26d8aadca1748b5"
             ]
         ]
     },
     {
-        "id": "4dc4fb8c3e5a1669",
+        "id": "adc3e37b03aa3340",
         "type": "function",
-        "z": "48ac861af1dcedb4",
-        "g": "0f9a11f670a00bdc",
+        "z": "23a4e27f08db4d94",
+        "g": "7f93f37162d70288",
         "name": "Loop start",
         "func": "// loop through the number of batteries set by the user\nmsg.battery_index = 1; // base-1\n\n// Init an array for battery status and value information\nmsg.batteries = [];\n\n// Continue\nreturn msg;",
         "outputs": 1,
@@ -6743,15 +2795,15 @@
         "y": 420,
         "wires": [
             [
-                "a421130d3420519b"
+                "3e22c7996a237cb0"
             ]
         ]
     },
     {
-        "id": "4917f809fff8eecb",
+        "id": "f37e720c2c2dd4bd",
         "type": "function",
-        "z": "48ac861af1dcedb4",
-        "g": "0f9a11f670a00bdc",
+        "z": "23a4e27f08db4d94",
+        "g": "7f93f37162d70288",
         "name": "Mapping",
         "func": "// Map to batteries array\nmsg.batteries.push({\n    id: `M${msg.battery_index}`,\n    power: parseInt(msg.battery_power,10),\n    charging_max: parseInt(msg.max_charge_power,10),\n    discharging_max: parseInt(msg.max_discharge_power,10),\n    soc: parseInt(msg.battery_state_of_charge,10),\n    soc_max: parseInt(msg.charging_cutoff_capacity,10),\n    soc_min: parseInt(msg.discharging_cutoff_capacity,10),\n    inverter: String(msg.inverter_state),\n    energy: Number(msg.battery_remaining_capacity),\n    energy_max: Number(msg.battery_total_energy),\n    rs485: String(msg.rs485_control_mode)\n    });\n\n// Continue\nreturn msg;",
         "outputs": 1,
@@ -6764,15 +2816,15 @@
         "y": 580,
         "wires": [
             [
-                "424e850ceb19ae8f"
+                "ba8167f993127056"
             ]
         ]
     },
     {
-        "id": "8bed63ea4d3de2fe",
+        "id": "a7d69f37a6f47ec6",
         "type": "switch",
-        "z": "48ac861af1dcedb4",
-        "g": "0f9a11f670a00bdc",
+        "z": "23a4e27f08db4d94",
+        "g": "7f93f37162d70288",
         "name": "Loop until",
         "property": "battery_index",
         "propertyType": "msg",
@@ -6793,18 +2845,18 @@
         "y": 580,
         "wires": [
             [
-                "a421130d3420519b"
+                "3e22c7996a237cb0"
             ],
             [
-                "98c9fb279c1085b0"
+                "0e13f180d79e0a7f"
             ]
         ]
     },
     {
-        "id": "60023d2aa6559b4b",
+        "id": "2a015f3c92bfdd5d",
         "type": "debug",
-        "z": "48ac861af1dcedb4",
-        "g": "0f9a11f670a00bdc",
+        "z": "23a4e27f08db4d94",
+        "g": "7f93f37162d70288",
         "name": "Loop result",
         "active": false,
         "tosidebar": true,
@@ -6819,10 +2871,10 @@
         "wires": []
     },
     {
-        "id": "d275a0ab915f2347",
+        "id": "99acf563ae5fd9cc",
         "type": "api-current-state",
-        "z": "48ac861af1dcedb4",
-        "g": "0f9a11f670a00bdc",
+        "z": "23a4e27f08db4d94",
+        "g": "7f93f37162d70288",
         "name": "Your battery count",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -6865,15 +2917,15 @@
         "y": 420,
         "wires": [
             [
-                "4dc4fb8c3e5a1669"
+                "adc3e37b03aa3340"
             ]
         ]
     },
     {
-        "id": "a421130d3420519b",
+        "id": "3e22c7996a237cb0",
         "type": "api-current-state",
-        "z": "48ac861af1dcedb4",
-        "g": "8b2ee74f2a91f366",
+        "z": "23a4e27f08db4d94",
+        "g": "240a191aa7efc2c6",
         "name": "Control mode",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -6916,15 +2968,15 @@
         "y": 500,
         "wires": [
             [
-                "3bc02df09d28dd4c"
+                "06a37ec093f227f7"
             ]
         ]
     },
     {
-        "id": "e889142eb16dd5f1",
+        "id": "9fcead626e6d0bf4",
         "type": "api-current-state",
-        "z": "48ac861af1dcedb4",
-        "g": "8b2ee74f2a91f366",
+        "z": "23a4e27f08db4d94",
+        "g": "240a191aa7efc2c6",
         "name": "SoC",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -6967,15 +3019,15 @@
         "y": 500,
         "wires": [
             [
-                "566b73ac710d9716"
+                "3c73013253faf6e4"
             ]
         ]
     },
     {
-        "id": "4b978b994b36bd63",
+        "id": "0fc3d288748feb7a",
         "type": "api-current-state",
-        "z": "48ac861af1dcedb4",
-        "g": "8b2ee74f2a91f366",
+        "z": "23a4e27f08db4d94",
+        "g": "240a191aa7efc2c6",
         "name": "Inverter state",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -7018,15 +3070,15 @@
         "y": 500,
         "wires": [
             [
-                "4a4eb3f1f1ef88f8"
+                "a02164b5186fa08b"
             ]
         ]
     },
     {
-        "id": "3a50c75b4a9cca8c",
+        "id": "7f8d8ad31fe0e884",
         "type": "api-current-state",
-        "z": "48ac861af1dcedb4",
-        "g": "8b2ee74f2a91f366",
+        "z": "23a4e27f08db4d94",
+        "g": "240a191aa7efc2c6",
         "name": "Max discharge power",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -7069,15 +3121,15 @@
         "y": 500,
         "wires": [
             [
-                "e889142eb16dd5f1"
+                "9fcead626e6d0bf4"
             ]
         ]
     },
     {
-        "id": "4a4eb3f1f1ef88f8",
+        "id": "a02164b5186fa08b",
         "type": "api-current-state",
-        "z": "48ac861af1dcedb4",
-        "g": "8b2ee74f2a91f366",
+        "z": "23a4e27f08db4d94",
+        "g": "240a191aa7efc2c6",
         "name": "Energy",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -7120,15 +3172,15 @@
         "y": 500,
         "wires": [
             [
-                "a619bbd2218439a8"
+                "5502544e6949ec66"
             ]
         ]
     },
     {
-        "id": "0f7e0893df46d003",
+        "id": "6c1de9041948c7f3",
         "type": "api-current-state",
-        "z": "48ac861af1dcedb4",
-        "g": "8b2ee74f2a91f366",
+        "z": "23a4e27f08db4d94",
+        "g": "240a191aa7efc2c6",
         "name": "Max charge power",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -7171,15 +3223,15 @@
         "y": 500,
         "wires": [
             [
-                "3a50c75b4a9cca8c"
+                "7f8d8ad31fe0e884"
             ]
         ]
     },
     {
-        "id": "3bc02df09d28dd4c",
+        "id": "06a37ec093f227f7",
         "type": "api-current-state",
-        "z": "48ac861af1dcedb4",
-        "g": "8b2ee74f2a91f366",
+        "z": "23a4e27f08db4d94",
+        "g": "240a191aa7efc2c6",
         "name": "Power",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -7222,15 +3274,15 @@
         "y": 500,
         "wires": [
             [
-                "0f7e0893df46d003"
+                "6c1de9041948c7f3"
             ]
         ]
     },
     {
-        "id": "e291af9808f2c0ec",
+        "id": "dabd641f02dd7bed",
         "type": "api-call-service",
-        "z": "48ac861af1dcedb4",
-        "g": "dbf744b373cca359",
+        "z": "23a4e27f08db4d94",
+        "g": "9e68177ca9323103",
         "name": "Node-RED status: OK",
         "server": "176d29a.6f648d6",
         "version": 7,
@@ -7259,10 +3311,10 @@
         ]
     },
     {
-        "id": "3f804e7d69164e0f",
+        "id": "8e80a92204bb72af",
         "type": "inject",
-        "z": "48ac861af1dcedb4",
-        "g": "dbf744b373cca359",
+        "z": "23a4e27f08db4d94",
+        "g": "9e68177ca9323103",
         "name": "On deploy",
         "props": [
             {
@@ -7284,16 +3336,16 @@
         "y": 60,
         "wires": [
             [
-                "d0d3c9732bef1bda",
-                "e2d0cf89de91a73a"
+                "788ccdab960fea67",
+                "21b7a17301542f47"
             ]
         ]
     },
     {
-        "id": "978b076ba86e2f14",
+        "id": "60e78d6e0a3941ea",
         "type": "api-call-service",
-        "z": "48ac861af1dcedb4",
-        "g": "cadf8c33c17cef4a",
+        "z": "23a4e27f08db4d94",
+        "g": "0f5639b779d2555c",
         "name": "Set mode (charge/discharge/stop)",
         "server": "176d29a.6f648d6",
         "version": 7,
@@ -7320,10 +3372,10 @@
         ]
     },
     {
-        "id": "0e5b65282514ed13",
+        "id": "6660c9537dc4dd69",
         "type": "function",
-        "z": "48ac861af1dcedb4",
-        "g": "cadf8c33c17cef4a",
+        "z": "23a4e27f08db4d94",
+        "g": "0f5639b779d2555c",
         "name": "Set Batteries",
         "func": "// Logger\nconst log = global.get(\"logger\");\n\n// enums\nconst CMODE = {\n    STOP: \"stop\", // Marstek batteries disconnect a relay when this is set or Power is 0W\n    CHARGE: \"charge\",\n    DISCHARGE: \"discharge\"\n}\n\n// Output format and target\nlet outputArray = [];\nlet solution = msg.solutions[msg.battery_index-1]; // Base-0, thus -1\nif (solution === undefined) {\n    log(this,`Can't find solution for index ${msg.battery_index - 1} in ${msg.solutions}, aborting...`,\"error\");\n    return null;\n}\nlet target = `marstek_${solution.id.toLowerCase()}`;\n\n// Safety | Id exists\nlet battery = msg.batteries.find(battery => battery.id === solution.id);\nif (battery === undefined) {\n    log(`Can't set battery ${solution.id}, aborting...`,\"error\");\n    return null;\n}\n// Safety | Power limit\nsolution.power = Math.min(solution.power, solution.mode == CMODE.CHARGE ? battery.charging_max: battery.discharging_max);\n\n// Set | Mode\nconst serviceCallMode = {\n    \"action\": \"select.select_option\",\n    \"target\": {\n        \"entity_id\": [`select.${target}_forcible_charge_discharge`]\n    },\n    \"data\": {\n         \"option\": String(solution.mode) // forced charge mode (stop, charge, discharge)\n    }\n};\n// Add topic to allow correct 'on change' filtering\noutputArray.push({payload: serviceCallMode, topic:solution.id});\n\n// Set | Power\nconst serviceCallPower = {\n    \"action\": \"number.set_value\",\n    \"target\": {\n        \"entity_id\": [\n            `number.${target}_forcible_charge_power`,\n            `number.${target}_forcible_discharge_power`\n            ]\n    },\n    \"data\": {\n        \"value\": Number(solution.power)\n    } \n};\n// Add topic to allow correct 'on change' filtering\noutputArray.push({payload: serviceCallPower, topic:solution.id});\n\n// Store service calls in msg to allow checking of loop results\nmsg.loop_result = { target, serviceCallMode, serviceCallPower };\n\n// Return msg as third output\noutputArray.push(msg);\n\n// Explain\nlog(this,`${target} ${String(solution.mode)} @ ${Number(solution.power)} Watt`);\n\n// Output\nreturn outputArray;",
         "outputs": 3,
@@ -7336,13 +3388,13 @@
         "y": 1400,
         "wires": [
             [
-                "978b076ba86e2f14"
+                "60e78d6e0a3941ea"
             ],
             [
-                "f7c4aa8d96bf64fd"
+                "f3e989b84435a7ec"
             ],
             [
-                "8214339bae8245c8"
+                "552cae4fe4d77d1a"
             ]
         ],
         "inputLabels": [
@@ -7355,10 +3407,10 @@
         ]
     },
     {
-        "id": "d6476ede2bd72be0",
+        "id": "eed5d9618a14368c",
         "type": "function",
-        "z": "48ac861af1dcedb4",
-        "g": "f76d0a5b93c10ffb",
+        "z": "23a4e27f08db4d94",
+        "g": "eefa9cb839c2d5b2",
         "name": "Loop start",
         "func": "// loop through the number of batteries set by the user\nmsg.battery_index = msg.battery_count;\n\n// Debug\nRED.util.setMessageProperty(msg, \"debug\", `## Cohort ${Date.now()} ##`);\n\n// Continue\nreturn msg;",
         "outputs": 1,
@@ -7371,15 +3423,15 @@
         "y": 1400,
         "wires": [
             [
-                "0e5b65282514ed13"
+                "6660c9537dc4dd69"
             ]
         ]
     },
     {
-        "id": "251ac10c55bdf4bc",
+        "id": "aa6220c6fbb17566",
         "type": "switch",
-        "z": "48ac861af1dcedb4",
-        "g": "cadf8c33c17cef4a",
+        "z": "23a4e27f08db4d94",
+        "g": "0f5639b779d2555c",
         "name": "Loop until",
         "property": "battery_index",
         "propertyType": "msg",
@@ -7400,18 +3452,18 @@
         "y": 1460,
         "wires": [
             [
-                "0e5b65282514ed13"
+                "6660c9537dc4dd69"
             ],
             [
-                "921b326acc2bb0ab"
+                "2360ad1424ef4c48"
             ]
         ]
     },
     {
-        "id": "8214339bae8245c8",
+        "id": "552cae4fe4d77d1a",
         "type": "function",
-        "z": "48ac861af1dcedb4",
-        "g": "cadf8c33c17cef4a",
+        "z": "23a4e27f08db4d94",
+        "g": "0f5639b779d2555c",
         "name": "Loop step",
         "func": "// Step index down\nmsg.battery_index -= 1;\n\n// Continue\nreturn msg;",
         "outputs": 1,
@@ -7424,16 +3476,16 @@
         "y": 1460,
         "wires": [
             [
-                "251ac10c55bdf4bc",
-                "040c74ee6223db71"
+                "aa6220c6fbb17566",
+                "c1f8e4728f5711c0"
             ]
         ]
     },
     {
-        "id": "a2940e104a89e48f",
+        "id": "5dbe8ec3e8f7943f",
         "type": "api-call-service",
-        "z": "48ac861af1dcedb4",
-        "g": "cadf8c33c17cef4a",
+        "z": "23a4e27f08db4d94",
+        "g": "0f5639b779d2555c",
         "name": "Set power (W)",
         "server": "176d29a.6f648d6",
         "version": 7,
@@ -7460,10 +3512,10 @@
         ]
     },
     {
-        "id": "499d4517ba5bcf18",
+        "id": "17dd2482cb99b862",
         "type": "function",
-        "z": "48ac861af1dcedb4",
-        "g": "f76d0a5b93c10ffb",
+        "z": "23a4e27f08db4d94",
+        "g": "eefa9cb839c2d5b2",
         "name": "Timing start",
         "func": "RED.util.setMessageProperty(msg,\"setbatteries.execution_start\",Date.now());\nRED.util.setMessageProperty(msg,\"setbatteries.marker\", `M1_${Date.now()}`);\nreturn msg;",
         "outputs": 1,
@@ -7476,15 +3528,15 @@
         "y": 1360,
         "wires": [
             [
-                "d6476ede2bd72be0"
+                "eed5d9618a14368c"
             ]
         ]
     },
     {
-        "id": "69873d54a2788a83",
+        "id": "6c6f92bd8ea7eb6d",
         "type": "switch",
-        "z": "48ac861af1dcedb4",
-        "g": "f76d0a5b93c10ffb",
+        "z": "23a4e27f08db4d94",
+        "g": "eefa9cb839c2d5b2",
         "name": "solutions present",
         "property": "solutions",
         "propertyType": "msg",
@@ -7507,18 +3559,18 @@
         "y": 1320,
         "wires": [
             [
-                "68bd6633d672835a"
+                "3d83f0a10274e5dd"
             ],
             [
-                "499d4517ba5bcf18"
+                "17dd2482cb99b862"
             ]
         ]
     },
     {
-        "id": "921b326acc2bb0ab",
+        "id": "2360ad1424ef4c48",
         "type": "function",
-        "z": "48ac861af1dcedb4",
-        "g": "f76d0a5b93c10ffb",
+        "z": "23a4e27f08db4d94",
+        "g": "eefa9cb839c2d5b2",
         "name": "Timing end",
         "func": "let start = RED.util.getMessageProperty(msg,\"setbatteries.execution_start\");\nlet end = Date.now();\nlet delta = end - start;\nlet timingString = `${delta/1000} sec`;\n\nnode.status({fill:\"green\",shape:\"dot\",text: timingString});\nmsg.delta = delta;\nmsg.timing = timingString;\n\nreturn msg;",
         "outputs": 1,
@@ -7531,16 +3583,16 @@
         "y": 1580,
         "wires": [
             [
-                "2e7fbbb3b27d2433",
-                "912e47b9312875f1"
+                "19484ad2b48e8585",
+                "4d69d6e21168fa27"
             ]
         ]
     },
     {
-        "id": "040c74ee6223db71",
+        "id": "c1f8e4728f5711c0",
         "type": "debug",
-        "z": "48ac861af1dcedb4",
-        "g": "cadf8c33c17cef4a",
+        "z": "23a4e27f08db4d94",
+        "g": "0f5639b779d2555c",
         "name": "Step result",
         "active": false,
         "tosidebar": true,
@@ -7555,10 +3607,10 @@
         "wires": []
     },
     {
-        "id": "f7c4aa8d96bf64fd",
+        "id": "f3e989b84435a7ec",
         "type": "rbe",
-        "z": "48ac861af1dcedb4",
-        "g": "cadf8c33c17cef4a",
+        "z": "23a4e27f08db4d94",
+        "g": "0f5639b779d2555c",
         "name": "on change",
         "func": "rbe",
         "gap": "",
@@ -7571,15 +3623,15 @@
         "y": 1400,
         "wires": [
             [
-                "a2940e104a89e48f"
+                "5dbe8ec3e8f7943f"
             ]
         ]
     },
     {
-        "id": "2e7fbbb3b27d2433",
+        "id": "19484ad2b48e8585",
         "type": "debug",
-        "z": "48ac861af1dcedb4",
-        "g": "f76d0a5b93c10ffb",
+        "z": "23a4e27f08db4d94",
+        "g": "eefa9cb839c2d5b2",
         "name": "Done",
         "active": true,
         "tosidebar": false,
@@ -7594,10 +3646,10 @@
         "wires": []
     },
     {
-        "id": "424e850ceb19ae8f",
+        "id": "ba8167f993127056",
         "type": "function",
-        "z": "48ac861af1dcedb4",
-        "g": "0f9a11f670a00bdc",
+        "z": "23a4e27f08db4d94",
+        "g": "7f93f37162d70288",
         "name": "Loop step",
         "func": "// Step index down\nmsg.battery_index += 1;\n\n// Continue\nreturn msg;",
         "outputs": 1,
@@ -7610,15 +3662,15 @@
         "y": 580,
         "wires": [
             [
-                "8bed63ea4d3de2fe"
+                "a7d69f37a6f47ec6"
             ]
         ]
     },
     {
-        "id": "93e4d6c51c83c9ae",
+        "id": "8e76bcf8b496fbd9",
         "type": "function",
-        "z": "48ac861af1dcedb4",
-        "g": "937b9038505ee9cb",
+        "z": "23a4e27f08db4d94",
+        "g": "deaa42a10caeb85b",
         "name": "Update battery order",
         "func": "// Cycles battery priority as follows\n// M=1 [1,2,3,4] | M=2 [2,3,4,1] | M=3 [3,4,1,2] | etc.\n// With M the battery to prioritize\n\n// msg.batteries (original order)\nlet currentArray = msg.batteries;\n\n// Prioritize the Mth battery\nconst M = RED.util.getMessageProperty(msg,\"prioritize_battery\") || 1;\n\n// 1st battery has prio? Skip and continue without change\nif (M==1) return msg;\n\n// N equals the number of items to take from the front to the back of the array, effectivly rotating battery priority\nconst N = M - 1; // base-0 version of M\nnode.status({fill:\"blue\",shape:\"ring\",text:`N = ${N}`});\n\n// 1. Check if the array is valid and long enough\nif (!Array.isArray(currentArray) || currentArray.length < N) {\n    // Send an error or the original array back if the array is invalid/too short\n    node.error(`Array is not valid or shorter than ${N} items.`, msg);\n    return null;\n}\n\n// 2. Get the first N items (these will go to the back)\n// slice(0, N) retrieves elements from the start (index 0) up to index N (exclusive).\nlet firstN = currentArray.slice(0, N);\n\n// 3. Get the remaining items (these will stay at the front)\n// slice(N) retrieves elements from index N to the end of the array.\nlet remaining = currentArray.slice(N);\n\n// 4. Concatenate them: remaining items (front) + first N items (back)\nlet newArray = remaining.concat(firstN);\n\n// 5. Place the new array back into msg.batteries\nmsg.batteries = newArray;\n\nreturn msg;\n",
         "outputs": 1,
@@ -7631,15 +3683,15 @@
         "y": 940,
         "wires": [
             [
-                "f9c760a42193f376"
+                "84caed3865b80c14"
             ]
         ]
     },
     {
-        "id": "0d693a1ee0231916",
+        "id": "814fda6266660353",
         "type": "inject",
-        "z": "48ac861af1dcedb4",
-        "g": "937b9038505ee9cb",
+        "z": "23a4e27f08db4d94",
+        "g": "deaa42a10caeb85b",
         "name": "Every day 02:00",
         "props": [
             {
@@ -7661,15 +3713,15 @@
         "y": 940,
         "wires": [
             [
-                "ed62a7fca13e0a8b"
+                "cc591d3541af3f68"
             ]
         ]
     },
     {
-        "id": "1076abf1997d083f",
+        "id": "804a344f635cb373",
         "type": "function",
-        "z": "48ac861af1dcedb4",
-        "g": "937b9038505ee9cb",
+        "z": "23a4e27f08db4d94",
+        "g": "deaa42a10caeb85b",
         "name": "Change priority",
         "func": "// Current prioritized battery is the Mth battery\nlet M = RED.util.getMessageProperty(msg,\"prioritize_battery\") || 1;\n\n// Prioritize the next battery\nM += 1;\n\n// If the next battery does not exist, prioritize the first again\nif(M > msg.battery_count) M = 1;\n\n// Pass along as payload\nmsg.payload = M;\n\n// Show which battery has priority\nnode.status({fill:\"green\",shape:\"dot\",text:`Prioritize battery #${M}`});\n\n// Done\nreturn msg;",
         "outputs": 1,
@@ -7682,15 +3734,15 @@
         "y": 940,
         "wires": [
             [
-                "ad4b688ddaf97afc"
+                "103d99e7fac0b8fa"
             ]
         ]
     },
     {
-        "id": "db89198b1ca39de8",
+        "id": "dca42b25d6b013e3",
         "type": "api-current-state",
-        "z": "48ac861af1dcedb4",
-        "g": "937b9038505ee9cb",
+        "z": "23a4e27f08db4d94",
+        "g": "deaa42a10caeb85b",
         "name": "Your battery count",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -7733,15 +3785,15 @@
         "y": 940,
         "wires": [
             [
-                "1076abf1997d083f"
+                "804a344f635cb373"
             ]
         ]
     },
     {
-        "id": "b3864d7a5371ab7a",
+        "id": "fac3effa820212e9",
         "type": "api-current-state",
-        "z": "48ac861af1dcedb4",
-        "g": "937b9038505ee9cb",
+        "z": "23a4e27f08db4d94",
+        "g": "deaa42a10caeb85b",
         "name": "Prioritize battery M",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -7784,15 +3836,15 @@
         "y": 940,
         "wires": [
             [
-                "93e4d6c51c83c9ae"
+                "8e76bcf8b496fbd9"
             ]
         ]
     },
     {
-        "id": "ad4b688ddaf97afc",
+        "id": "103d99e7fac0b8fa",
         "type": "api-call-service",
-        "z": "48ac861af1dcedb4",
-        "g": "937b9038505ee9cb",
+        "z": "23a4e27f08db4d94",
+        "g": "deaa42a10caeb85b",
         "name": "Update prioritized battery",
         "server": "176d29a.6f648d6",
         "version": 7,
@@ -7821,10 +3873,10 @@
         ]
     },
     {
-        "id": "ed62a7fca13e0a8b",
+        "id": "cc591d3541af3f68",
         "type": "api-current-state",
-        "z": "48ac861af1dcedb4",
-        "g": "937b9038505ee9cb",
+        "z": "23a4e27f08db4d94",
+        "g": "deaa42a10caeb85b",
         "name": "Desired interval",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -7861,15 +3913,15 @@
         "y": 940,
         "wires": [
             [
-                "6b4d2555302ec384"
+                "9b187fcddad353b9"
             ]
         ]
     },
     {
-        "id": "6b4d2555302ec384",
+        "id": "9b187fcddad353b9",
         "type": "function",
-        "z": "48ac861af1dcedb4",
-        "g": "937b9038505ee9cb",
+        "z": "23a4e27f08db4d94",
+        "g": "deaa42a10caeb85b",
         "name": "Check interval ",
         "func": "// Manual priority, never pass\nif(msg.payload == \"Never\") {\n    node.status({fill:\"yellow\",shape:\"dot\",text:\"Auto cycle disabled\"});\n    return null;\n}\n\n// Daily interval, always pass\nif(msg.payload == \"Daily\") {\n    node.status({ fill: \"green\", shape: \"dot\", text: `Pass` });\n    return msg;\n}\n\n// Weekly interval\nconst today = new Date();\n// Get the day of the week (0 = Sunday, 1 = Monday, ..., 6 = Saturday)\nconst dayOfWeek = today.getDay();\n\n// Check if the day is Sunday (which is represented by the number 0)\nif (dayOfWeek === 0) {\n    // If it is Sunday, pass\n    node.status({ fill: \"green\", shape: \"dot\", text: `Passed on Sunday` });\n    return msg;\n} else {\n    // If it is not Sunday, stop\n    node.status({ fill: \"yellow\", shape: \"dot\", text: `Halted, not Sunday` });\n    return null;\n}",
         "outputs": 1,
@@ -7882,15 +3934,15 @@
         "y": 940,
         "wires": [
             [
-                "8ab1721d5fd454ce"
+                "b749a0c365b88ab0"
             ]
         ]
     },
     {
-        "id": "8ab1721d5fd454ce",
+        "id": "b749a0c365b88ab0",
         "type": "api-current-state",
-        "z": "48ac861af1dcedb4",
-        "g": "937b9038505ee9cb",
+        "z": "23a4e27f08db4d94",
+        "g": "deaa42a10caeb85b",
         "name": "Current priority",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -7933,15 +3985,15 @@
         "y": 940,
         "wires": [
             [
-                "db89198b1ca39de8"
+                "dca42b25d6b013e3"
             ]
         ]
     },
     {
-        "id": "8e95e6fefa2012d8",
+        "id": "71664a6ed9350cc4",
         "type": "function",
-        "z": "48ac861af1dcedb4",
-        "g": "ef23da74434d55e4",
+        "z": "23a4e27f08db4d94",
+        "g": "200775166ba1a27b",
         "name": "Batteries (totals)",
         "func": "// batteries | calculate total and max. power delivered by batteries\nlet batteries = msg.batteries;\nlet batteries_total_power = 0;\nlet batteries_max_charging_power = 0;\nlet batteries_max_discharging_power = 0;\nlet batteries_available_energy = 0;\nlet batteries_max_energy = 0;\n\nbatteries.forEach(battery => {\n    batteries_total_power += Number(battery.power);\n    batteries_max_charging_power += Number(battery.charging_max);\n    batteries_max_discharging_power += Number(battery.discharging_max);\n    batteries_available_energy += Number(battery.energy - battery.energy_max*battery.soc_min/100);\n    batteries_max_energy += (Number(battery.energy_max*battery.soc_max) - Number(battery.energy_max*battery.soc_min))/100; // kWh\n});\n\n// OUTPUT\nRED.util.setMessageProperty(msg, \"batteries_total_power\", batteries_total_power, true); // W\nRED.util.setMessageProperty(msg, \"batteries_max_charge_power\", batteries_max_charging_power,true); // W\nRED.util.setMessageProperty(msg, \"batteries_max_discharge_power\", batteries_max_discharging_power,true); // W\nRED.util.setMessageProperty(msg, \"batteries_available_energy\",batteries_available_energy,true); // kWh usable\nRED.util.setMessageProperty(msg, \"batteries_max_energy\", batteries_max_energy, true); // kWh usable\nreturn msg;",
         "outputs": 1,
@@ -7954,9 +4006,9 @@
         "y": 680,
         "wires": [
             [
-                "b3864d7a5371ab7a",
-                "ce1f525f7b16288e",
-                "9d862d9e9136e191"
+                "fac3effa820212e9",
+                "6038c75de7aac7e5",
+                "6236b1eaca325c8d"
             ]
         ],
         "inputLabels": [
@@ -7964,10 +4016,10 @@
         ]
     },
     {
-        "id": "a619bbd2218439a8",
+        "id": "5502544e6949ec66",
         "type": "api-current-state",
-        "z": "48ac861af1dcedb4",
-        "g": "8b2ee74f2a91f366",
+        "z": "23a4e27f08db4d94",
+        "g": "240a191aa7efc2c6",
         "name": "Energy max",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -8010,15 +4062,15 @@
         "y": 500,
         "wires": [
             [
-                "4917f809fff8eecb"
+                "f37e720c2c2dd4bd"
             ]
         ]
     },
     {
-        "id": "98c9fb279c1085b0",
+        "id": "0e13f180d79e0a7f",
         "type": "function",
-        "z": "48ac861af1dcedb4",
-        "g": "0f9a11f670a00bdc",
+        "z": "23a4e27f08db4d94",
+        "g": "7f93f37162d70288",
         "name": "Loop end",
         "func": "// cleanup \ndelete msg.battery_index;\n\ndelete msg.battery_power;\ndelete msg.max_charge_power;\ndelete msg.max_discharge_power;\ndelete msg.battery_state_of_charge;\ndelete msg.charging_cutoff_capacity;\ndelete msg.discharging_cutoff_capacity;\ndelete msg.inverter_state;\ndelete msg.battery_remaining_capacity;\ndelete msg.battery_total_energy;\ndelete msg.rs485_control_mode;\n\nreturn msg;",
         "outputs": 1,
@@ -8031,16 +4083,16 @@
         "y": 580,
         "wires": [
             [
-                "60023d2aa6559b4b",
-                "8e95e6fefa2012d8"
+                "2a015f3c92bfdd5d",
+                "71664a6ed9350cc4"
             ]
         ]
     },
     {
-        "id": "e37a0ee09b1186d1",
+        "id": "a2fc19c1d5226f60",
         "type": "api-call-service",
-        "z": "48ac861af1dcedb4",
-        "g": "a6ef66efd42a9f79",
+        "z": "23a4e27f08db4d94",
+        "g": "8147fe89476d8165",
         "name": "Usable energy",
         "server": "176d29a.6f648d6",
         "version": 7,
@@ -8069,10 +4121,10 @@
         ]
     },
     {
-        "id": "860e283819486c58",
+        "id": "616b4e11c9cd9b86",
         "type": "rbe",
-        "z": "48ac861af1dcedb4",
-        "g": "a6ef66efd42a9f79",
+        "z": "23a4e27f08db4d94",
+        "g": "8147fe89476d8165",
         "name": "On change",
         "func": "rbe",
         "gap": "",
@@ -8085,15 +4137,15 @@
         "y": 680,
         "wires": [
             [
-                "e37a0ee09b1186d1"
+                "a2fc19c1d5226f60"
             ]
         ]
     },
     {
-        "id": "8d8f01b0bddf8eb5",
+        "id": "e42a77152ac7634f",
         "type": "switch",
-        "z": "48ac861af1dcedb4",
-        "g": "0d316b1cf81f65b1",
+        "z": "23a4e27f08db4d94",
+        "g": "149350c2395c5836",
         "name": "Select rate limit",
         "property": "p1_rate_limit.save_power",
         "propertyType": "msg",
@@ -8112,18 +4164,18 @@
         "y": 280,
         "wires": [
             [
-                "89ba4d5f72b21b76"
+                "a9896eeb1ac753d3"
             ],
             [
-                "70acaaa579c0a018"
+                "57bbefb5c23f0fc4"
             ]
         ]
     },
     {
-        "id": "dec4611b05fb5eed",
+        "id": "b65f73ccee8a2637",
         "type": "delay",
-        "z": "48ac861af1dcedb4",
-        "g": "0d316b1cf81f65b1",
+        "z": "23a4e27f08db4d94",
+        "g": "149350c2395c5836",
         "name": "Rate limit",
         "pauseType": "rate",
         "timeout": "5",
@@ -8141,10 +4193,10 @@
         "y": 280,
         "wires": [
             [
-                "52d1f3da35515e31"
+                "51d579827f73db87"
             ],
             [
-                "bf7835ad1be027e8"
+                "9ca8e9d6fa4dca81"
             ]
         ],
         "outputLabels": [
@@ -8153,10 +4205,10 @@
         ]
     },
     {
-        "id": "70acaaa579c0a018",
+        "id": "57bbefb5c23f0fc4",
         "type": "change",
-        "z": "48ac861af1dcedb4",
-        "g": "0d316b1cf81f65b1",
+        "z": "23a4e27f08db4d94",
+        "g": "149350c2395c5836",
         "name": "1 msg/s",
         "rules": [
             {
@@ -8176,15 +4228,15 @@
         "y": 300,
         "wires": [
             [
-                "dec4611b05fb5eed"
+                "b65f73ccee8a2637"
             ]
         ]
     },
     {
-        "id": "89ba4d5f72b21b76",
+        "id": "a9896eeb1ac753d3",
         "type": "change",
-        "z": "48ac861af1dcedb4",
-        "g": "0d316b1cf81f65b1",
+        "z": "23a4e27f08db4d94",
+        "g": "149350c2395c5836",
         "name": "0.333 msg/s",
         "rules": [
             {
@@ -8204,15 +4256,15 @@
         "y": 260,
         "wires": [
             [
-                "dec4611b05fb5eed"
+                "b65f73ccee8a2637"
             ]
         ]
     },
     {
-        "id": "81672b5662a971ac",
+        "id": "caddfac7e1a76c06",
         "type": "function",
-        "z": "48ac861af1dcedb4",
-        "g": "0d316b1cf81f65b1",
+        "z": "23a4e27f08db4d94",
+        "g": "149350c2395c5836",
         "name": "P1 change (20W or 2%)",
         "func": "// Switch between low and high rate limiting to decrease load and power consumption\n// --\n// The flow should always be rate limited by atleast the total execution time of strategies\n// The flow should not lock up indefinitly when grid_power is constant.\n// In the latter case, a more relaxed rate limit can help reduce system load.\n// Devs: don't set msg.rate directly. Use nodes, so novice users can easily read the flow.\n\n// Thresholds for change in power, before switching to high rate limit\nconst THRESHOLD_POWER = 20; // Watt change\nconst THRESHOLD_PERCENT = 2; // Percentage\nRED.util.setMessageProperty(msg, \"p1_rate_limit.threshold_power\", THRESHOLD_POWER,true);\nRED.util.setMessageProperty(msg, \"p1_rate_limit.threshold_percent\", THRESHOLD_PERCENT, true);\n\n// Get the previous value from this node's context\n// If it doesn't exist yet, initialize it as null\nlet previousValue = context.get('previousValue') || null;\nlet currentValue = Number(msg.grid_power);\n\n// Save the current value for the next time the node is triggered\ncontext.set('previousValue', currentValue);\n\n// Default rate limiting\nRED.util.setMessageProperty(msg,\"p1_rate_limit.save_power\",true);\n\n// Check if we have a valid history to compare with\nif (previousValue !== null) {\n    let powerChange = Math.abs(currentValue - previousValue);\n    let percentageChange = previousValue !== 0 ? Math.abs((powerChange / previousValue) * 100):0;\n\n    // Condition: Absolute difference > N Watt AND percentage change > M %\n    if (powerChange > THRESHOLD_POWER && percentageChange > THRESHOLD_PERCENT) {\n        // Enable faster refresh rate\n        RED.util.setMessageProperty(msg,\"p1_rate_limit.save_power\",false);\n    }\n}\n\nreturn msg;",
         "outputs": 1,
@@ -8225,15 +4277,15 @@
         "y": 280,
         "wires": [
             [
-                "8d8f01b0bddf8eb5"
+                "e42a77152ac7634f"
             ]
         ]
     },
     {
-        "id": "f4e32c63a96c3fa8",
+        "id": "182d1ff7fbffc581",
         "type": "function",
-        "z": "48ac861af1dcedb4",
-        "g": "0d316b1cf81f65b1",
+        "z": "23a4e27f08db4d94",
+        "g": "149350c2395c5836",
         "name": "CPU power saved",
         "func": "// Logger\nconst logger = global.get(\"logger\");\n\n// Passed or blocked\nconst hasPassed = msg.payload; // 0 = blocked, 1 = passed\n\n// 1. Get evaluations (Total attempts)\nlet evaluations = (context.get(\"p1_rate_limit_evaluations\") || 0) + 1;\ncontext.set(\"p1_rate_limit_evaluations\", evaluations);\n\n// 2. Increment and get passes (Filtered/successful events)\nlet passes = (context.get(\"p1_rate_limit_passes\") || 0) + hasPassed;\ncontext.set(\"p1_rate_limit_passes\", passes);\n\n// 3a. Calculate percentage (Rate of passing vs total evaluations)\nlet percentage = evaluations > 0 ? (passes / evaluations) * 100 : 0;\n// 3b. Display the percentage rate of not-passing as a measure of efficiency gained\npercentage = 100 - percentage;\n\n// 4. Update Node Status\nnode.status({\n    fill: \"blue\",\n    shape: \"dot\",\n    text: `Saved: ${percentage.toFixed(2)}% (${evaluations-passes}/${evaluations})`\n});\n\n// 5. Explain\n// On block\nif(hasPassed === 0) {\n    if(msg.p1_rate_limit.save_power === true) {\n        // This is good\n        logger(this, `<font color=\"#009ac7\">Power saved</font> by P1 Rate Limiter, execution stopped.`); \n    } else {\n        // This is not so good. P1 updates are coming in fast.\n        logger(this, `<font color=\"orange\">Blocked</font> by P1 Rate Limiter. ${Number(1000/msg.rate).toFixed(2)} messages per second exceeded.`); \n    }\n    \n    // Send message onward to debug dashboard\n    return msg;\n}\n// No output on pass\nreturn null;",
         "outputs": 1,
@@ -8246,15 +4298,15 @@
         "y": 280,
         "wires": [
             [
-                "19ddc55e9b42a045"
+                "8306f2a8e81443f8"
             ]
         ]
     },
     {
-        "id": "4177e91aeda624f2",
+        "id": "c48cbfe9a99734a4",
         "type": "debug",
-        "z": "48ac861af1dcedb4",
-        "g": "9b07562053189234",
+        "z": "23a4e27f08db4d94",
+        "g": "d0359c3b08e2f524",
         "name": "Strategy evaluation",
         "active": false,
         "tosidebar": true,
@@ -8269,10 +4321,10 @@
         "wires": []
     },
     {
-        "id": "55a4b32873e6e385",
+        "id": "a571f72edce4f9b7",
         "type": "api-call-service",
-        "z": "48ac861af1dcedb4",
-        "g": "061960f18498b1de",
+        "z": "23a4e27f08db4d94",
+        "g": "6434c6187d2b1dcc",
         "name": "Show on dashboard",
         "server": "176d29a.6f648d6",
         "version": 7,
@@ -8301,10 +4353,10 @@
         ]
     },
     {
-        "id": "85a54c063f523e6a",
+        "id": "b26d8aadca1748b5",
         "type": "api-current-state",
-        "z": "48ac861af1dcedb4",
-        "g": "061960f18498b1de",
+        "z": "23a4e27f08db4d94",
+        "g": "6434c6187d2b1dcc",
         "name": "current UI value",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -8347,15 +4399,15 @@
         "y": 1220,
         "wires": [
             [
-                "52d50e57e542972f"
+                "20dddde2b06aae74"
             ]
         ]
     },
     {
-        "id": "52d50e57e542972f",
+        "id": "20dddde2b06aae74",
         "type": "function",
-        "z": "48ac861af1dcedb4",
-        "g": "061960f18498b1de",
+        "z": "23a4e27f08db4d94",
+        "g": "6434c6187d2b1dcc",
         "name": "on new UI value",
         "func": "// Block when undefined (don't update UI)\nif(msg.ui_value_current === undefined) return null;\n\n// We show the 2nd strategy in the trace (if available) on the dashboard as the 'active sub-strategy'\nconst secondTraceEntry = msg.strategy?.trace?.[1];\nif (secondTraceEntry) {\n    // Handle case where 2nd flow is present\n    msg.ui_value_new =  secondTraceEntry.flow;\n} else {\n    // Handle case where the 2nd flow is missing\n    // Get a sensible alternative\n    msg.ui_value_new = msg.strategy?.selected || \"\"; // don't use unknown or unavailable as these are reserved HA keywords\n}\n\n// Improve human readability\nif(msg.ui_value_new == \"Self-consumption\" && secondTraceEntry?.flow_settings?.discharge_disabled === true){\n    msg.ui_value_new = \"Self-consumption (charge only)\";\n}\nif(msg.ui_value_new == \"Self-consumption\" && secondTraceEntry?.flow_settings?.charge_disabled === true){\n    msg.ui_value_new = \"Self-consumption (no charging)\";\n}\nif(msg.strategy?.is_peak_shaving === true){\n    msg.ui_value_new = \"Peak shaving\";\n}\n\n// Node status for devs\nnode.status({fill:\"grey\",shape:\"dot\",text:`new: ${msg.ui_value_new}`});\n\n// Block when equal (don't update UI)\nif(msg.ui_value_current === msg.ui_value_new) return null;\n\n// Pass otherwise\nreturn msg;",
         "outputs": 1,
@@ -8368,15 +4420,15 @@
         "y": 1220,
         "wires": [
             [
-                "55a4b32873e6e385"
+                "a571f72edce4f9b7"
             ]
         ]
     },
     {
-        "id": "abf9c4cf036aa0e8",
+        "id": "e711da3f1e47c6df",
         "type": "ha-fire-event",
-        "z": "48ac861af1dcedb4",
-        "g": "3c9ce920dfcd2460",
+        "z": "23a4e27f08db4d94",
+        "g": "9ecdfccab179a392",
         "name": "Show on debug board",
         "server": "176d29a.6f648d6",
         "version": 0,
@@ -8390,10 +4442,10 @@
         ]
     },
     {
-        "id": "c5a35a3e13c3974a",
+        "id": "622625722f27fd1d",
         "type": "api-current-state",
-        "z": "48ac861af1dcedb4",
-        "g": "829c23ac2351a872",
+        "z": "23a4e27f08db4d94",
+        "g": "c9cd464ac5e9dea8",
         "name": "Insight mode",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -8436,15 +4488,15 @@
         "y": 160,
         "wires": [
             [
-                "62b3339349fc6e88"
+                "f40438b466155cb5"
             ]
         ]
     },
     {
-        "id": "912e47b9312875f1",
+        "id": "4d69d6e21168fa27",
         "type": "switch",
-        "z": "48ac861af1dcedb4",
-        "g": "3c9ce920dfcd2460",
+        "z": "23a4e27f08db4d94",
+        "g": "9ecdfccab179a392",
         "name": "Debug mode?",
         "property": "debug_mode",
         "propertyType": "global",
@@ -8460,15 +4512,15 @@
         "y": 1580,
         "wires": [
             [
-                "abf9c4cf036aa0e8"
+                "e711da3f1e47c6df"
             ]
         ]
     },
     {
-        "id": "09206d9eaa5cd7a8",
+        "id": "d902acd1ee5701c2",
         "type": "server-state-changed",
-        "z": "48ac861af1dcedb4",
-        "g": "829c23ac2351a872",
+        "z": "23a4e27f08db4d94",
+        "g": "c9cd464ac5e9dea8",
         "name": "Turned ON",
         "server": "176d29a.6f648d6",
         "version": 6,
@@ -8519,16 +4571,16 @@
         "y": 160,
         "wires": [
             [
-                "2cbf3380b1b0897d"
+                "a916cb28cbb336ed"
             ],
             []
         ]
     },
     {
-        "id": "2cbf3380b1b0897d",
+        "id": "a916cb28cbb336ed",
         "type": "trigger",
-        "z": "48ac861af1dcedb4",
-        "g": "829c23ac2351a872",
+        "z": "23a4e27f08db4d94",
+        "g": "c9cd464ac5e9dea8",
         "name": "disable after 5 minutes",
         "op1": "",
         "op2": "off",
@@ -8546,15 +4598,15 @@
         "y": 160,
         "wires": [
             [
-                "120283b1e9cd1293"
+                "4073f070084bd785"
             ]
         ]
     },
     {
-        "id": "120283b1e9cd1293",
+        "id": "4073f070084bd785",
         "type": "api-call-service",
-        "z": "48ac861af1dcedb4",
-        "g": "829c23ac2351a872",
+        "z": "23a4e27f08db4d94",
+        "g": "c9cd464ac5e9dea8",
         "name": "Turn insight OFF",
         "server": "176d29a.6f648d6",
         "version": 7,
@@ -8583,10 +4635,10 @@
         ]
     },
     {
-        "id": "d0d3c9732bef1bda",
+        "id": "788ccdab960fea67",
         "type": "delay",
-        "z": "48ac861af1dcedb4",
-        "g": "dbf744b373cca359",
+        "z": "23a4e27f08db4d94",
+        "g": "9e68177ca9323103",
         "name": "",
         "pauseType": "delay",
         "timeout": "2",
@@ -8604,15 +4656,15 @@
         "y": 60,
         "wires": [
             [
-                "e291af9808f2c0ec"
+                "dabd641f02dd7bed"
             ]
         ]
     },
     {
-        "id": "e2d0cf89de91a73a",
+        "id": "21b7a17301542f47",
         "type": "function",
-        "z": "48ac861af1dcedb4",
-        "g": "05453bf97681f245",
+        "z": "23a4e27f08db4d94",
+        "g": "693e9f2c3d7c4bdc",
         "name": "Custom logger",
         "func": "/**\n * Custom Logger Function\n * * Provides centralized logging, node-status updates, and message tracing.\n * Specifically designed for Home Battery Control logic within Node-RED.\n * \n * Debug dashboard updating:\n * A msg needs to reach 'Strategy Evaluation' or be passed to the \"Show on debug board\" trigger node.\n * Errors are automatically passed to the \"Show on debug board\" trigger node.\n * \n * * @param {object} callingNode - The context of the calling node (pass 'this').\n * @param {string} text - The log message/explanation.\n * @param {string} level - Log level: 'log', 'warn', 'error', or 'info' (default: 'info').\n * \n * Note: anything above 'info' will also write to the Node-RED log files \n * \n * * @usage: \n * const log = global.get(\"logger\");\n * log(this, \"Charging cycle started\");\n */\nconst customLogger = (callingNode, text, level = 'info') => {\n    \n    // Log only when debug_mode is ON\n    const debug_mode = global.get(\"debug_mode\") || false;\n    if(debug_mode == false) return null;\n\n    // Max log elements to keep\n    const MAX_ELEMENTS = 100;\n\n    // Create the YYYY-MM-DD HH:MM:SS.mmm format\n    const now = new Date();\n    const timestamp = now.getHours().toString().padStart(2, '0') + \":\" +\n                now.getMinutes().toString().padStart(2, '0') + \":\" +\n                now.getSeconds().toString().padStart(2, '0') + \".\" +\n                now.getMilliseconds().toString().padStart(3, '0');\n\n    const formattedTimeLevel = `${timestamp} [${level.toLowerCase()}]`;\n    \n    // Get the name of the node or fallback to the ID\n    const nodeName = callingNode.__node__ ? callingNode.__node__.name || callingNode.__node__.id : undefined;\n    // Get the name of the Flow/Tab\n    const flowName = callingNode.env.get(\"NR_FLOW_NAME\") || \"Unknown flow\";\n    // Explain to the Home Battery Control user what is going on\n    const formattedExplenation = `[${flowName} >> ${nodeName}]: ${text}`;\n\n    // Level icons\n    let icon = \"⚪\";\n    switch (level) {\n        case \"info\":\n            icon = \"ℹ️\";\n            break;\n        case \"log\":\n            icon = \"🔧\";\n            break;\n        case \"warn\":\n            icon = \"⚠️\";      \n            break;\n        case \"error\":\n            icon = \"❌\";\n            break;\n    }\n\n    // Enrich msg with log info\n    const msg = callingNode.msg;\n    (msg.log = msg.log || []).push({ timestamp: timestamp, level:level, flow:flowName, node:nodeName, payload: text, icon: icon});\n\n    if (msg.log.length > MAX_ELEMENTS) {\n        // Slice keeps the last X elements\n        msg.log = msg.log.slice(-MAX_ELEMENTS);\n    }\n\n    // Log to the Node-RED system log\n    switch (level) {\n        case \"log\":\n            node.log(`${formattedExplenation}`);\n            break;\n        case \"warn\":\n            node.warn(`${formattedExplenation}`);       \n            break;\n        case \"error\":\n            node.error(`${formattedExplenation}`, callingNode.msg);\n            break;\n        default:\n            // don't log to logfiles by default\n    }\n\n};\n\nglobal.set('logger', customLogger);\nglobal.set('unhandledException', \"\");\nreturn msg;",
         "outputs": 1,
@@ -8625,15 +4677,15 @@
         "y": 160,
         "wires": [
             [
-                "c68009c541635661"
+                "b7d4d52c1c2d4a54"
             ]
         ]
     },
     {
-        "id": "52d1f3da35515e31",
+        "id": "51d579827f73db87",
         "type": "change",
-        "z": "48ac861af1dcedb4",
-        "g": "0d316b1cf81f65b1",
+        "z": "23a4e27f08db4d94",
+        "g": "149350c2395c5836",
         "name": "Pass",
         "rules": [
             {
@@ -8653,16 +4705,16 @@
         "y": 300,
         "wires": [
             [
-                "f4e32c63a96c3fa8",
-                "84d53eaf9442ab0c"
+                "182d1ff7fbffc581",
+                "ecd0aa22731ed65e"
             ]
         ]
     },
     {
-        "id": "bf7835ad1be027e8",
+        "id": "9ca8e9d6fa4dca81",
         "type": "change",
-        "z": "48ac861af1dcedb4",
-        "g": "0d316b1cf81f65b1",
+        "z": "23a4e27f08db4d94",
+        "g": "149350c2395c5836",
         "name": "Block",
         "rules": [
             {
@@ -8682,68 +4734,68 @@
         "y": 260,
         "wires": [
             [
-                "f4e32c63a96c3fa8"
+                "182d1ff7fbffc581"
             ]
         ]
     },
     {
-        "id": "23f62d92e226dfaf",
+        "id": "f1d65a7781683032",
         "type": "link in",
-        "z": "48ac861af1dcedb4",
-        "g": "3c9ce920dfcd2460",
+        "z": "23a4e27f08db4d94",
+        "g": "9ecdfccab179a392",
         "name": "Update debug dashboard",
         "links": [
-            "19ddc55e9b42a045",
-            "68bd6633d672835a",
-            "2f3213f3bb3c7592"
+            "8306f2a8e81443f8",
+            "3d83f0a10274e5dd",
+            "c9416ef63c9c3561"
         ],
         "x": 1395,
         "y": 1520,
         "wires": [
             [
-                "912e47b9312875f1",
-                "4376ef9c525c603a"
+                "4d69d6e21168fa27",
+                "56d0b7562c7c206f"
             ]
         ]
     },
     {
-        "id": "19ddc55e9b42a045",
+        "id": "8306f2a8e81443f8",
         "type": "link out",
-        "z": "48ac861af1dcedb4",
-        "g": "0d316b1cf81f65b1",
+        "z": "23a4e27f08db4d94",
+        "g": "149350c2395c5836",
         "name": "goto Debug Dashboard update",
         "mode": "link",
         "links": [
-            "23f62d92e226dfaf"
+            "f1d65a7781683032"
         ],
         "x": 1395,
         "y": 280,
         "wires": []
     },
     {
-        "id": "2e959ec089b8532d",
+        "id": "d859b7c6ac97aa9f",
         "type": "catch",
-        "z": "48ac861af1dcedb4",
-        "g": "3c9ce920dfcd2460",
+        "z": "23a4e27f08db4d94",
+        "g": "9ecdfccab179a392",
         "name": "Custom logger",
         "scope": [
-            "e2d0cf89de91a73a"
+            "21b7a17301542f47"
         ],
         "uncaught": false,
         "x": 1340,
         "y": 1640,
         "wires": [
             [
-                "912e47b9312875f1",
-                "c0aa8ebae2966431"
+                "4d69d6e21168fa27",
+                "966c3872c694eadd"
             ]
         ]
     },
     {
-        "id": "c0aa8ebae2966431",
+        "id": "966c3872c694eadd",
         "type": "debug",
-        "z": "48ac861af1dcedb4",
-        "g": "3c9ce920dfcd2460",
+        "z": "23a4e27f08db4d94",
+        "g": "9ecdfccab179a392",
         "name": "Via Catch",
         "active": true,
         "tosidebar": false,
@@ -8758,10 +4810,10 @@
         "wires": []
     },
     {
-        "id": "4376ef9c525c603a",
+        "id": "56d0b7562c7c206f",
         "type": "debug",
-        "z": "48ac861af1dcedb4",
-        "g": "3c9ce920dfcd2460",
+        "z": "23a4e27f08db4d94",
+        "g": "9ecdfccab179a392",
         "name": "Via link",
         "active": true,
         "tosidebar": false,
@@ -8776,24 +4828,24 @@
         "wires": []
     },
     {
-        "id": "68bd6633d672835a",
+        "id": "3d83f0a10274e5dd",
         "type": "link out",
-        "z": "48ac861af1dcedb4",
-        "g": "f76d0a5b93c10ffb",
+        "z": "23a4e27f08db4d94",
+        "g": "eefa9cb839c2d5b2",
         "name": "link out 1",
         "mode": "link",
         "links": [
-            "23f62d92e226dfaf"
+            "f1d65a7781683032"
         ],
         "x": 285,
         "y": 1320,
         "wires": []
     },
     {
-        "id": "103b546ad9e1d00e",
+        "id": "abc4f73f1f878035",
         "type": "switch",
-        "z": "48ac861af1dcedb4",
-        "g": "0d316b1cf81f65b1",
+        "z": "23a4e27f08db4d94",
+        "g": "149350c2395c5836",
         "name": "Skip rate limiter during debug",
         "property": "debug_mode",
         "propertyType": "global",
@@ -8812,18 +4864,18 @@
         "y": 280,
         "wires": [
             [
-                "81672b5662a971ac"
+                "caddfac7e1a76c06"
             ],
             [
-                "84d53eaf9442ab0c"
+                "ecd0aa22731ed65e"
             ]
         ]
     },
     {
-        "id": "62b3339349fc6e88",
+        "id": "f40438b466155cb5",
         "type": "function",
-        "z": "48ac861af1dcedb4",
-        "g": "829c23ac2351a872",
+        "z": "23a4e27f08db4d94",
+        "g": "c9cd464ac5e9dea8",
         "name": "Notice",
         "func": "// enable or disable Insights Mode\nif(msg.debug_mode == \"on\"){\n    // ENABLED - explain to user\n    const log = global.get(\"logger\");\n    log(this, \"P1 Rate limiter is *disabled* during *debug mode*\");\n\n    // Set global (setting this via current state node has proven irriliable)\n    global.set(\"debug_mode\", true);\n} else {\n    // DISABLED - set global\n    global.set(\"debug_mode\", false);\n}\n\n// Clean up - only use the global\ndelete msg.debug_mode;\n\nreturn msg;",
         "outputs": 1,
@@ -8836,16 +4888,16 @@
         "y": 160,
         "wires": [
             [
-                "8943b2424b61435b"
+                "02b5708478962713"
             ]
         ],
         "l": false
     },
     {
-        "id": "566b73ac710d9716",
+        "id": "3c73013253faf6e4",
         "type": "api-current-state",
-        "z": "48ac861af1dcedb4",
-        "g": "8b2ee74f2a91f366",
+        "z": "23a4e27f08db4d94",
+        "g": "240a191aa7efc2c6",
         "name": "SoC min",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -8888,15 +4940,15 @@
         "y": 500,
         "wires": [
             [
-                "35b0c7bbe1aa6cbb"
+                "9823984049faf224"
             ]
         ]
     },
     {
-        "id": "35b0c7bbe1aa6cbb",
+        "id": "9823984049faf224",
         "type": "api-current-state",
-        "z": "48ac861af1dcedb4",
-        "g": "8b2ee74f2a91f366",
+        "z": "23a4e27f08db4d94",
+        "g": "240a191aa7efc2c6",
         "name": "SoC max",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -8939,15 +4991,15 @@
         "y": 500,
         "wires": [
             [
-                "4b978b994b36bd63"
+                "0fc3d288748feb7a"
             ]
         ]
     },
     {
-        "id": "c68009c541635661",
+        "id": "b7d4d52c1c2d4a54",
         "type": "function",
-        "z": "48ac861af1dcedb4",
-        "g": "05453bf97681f245",
+        "z": "23a4e27f08db4d94",
+        "g": "693e9f2c3d7c4bdc",
         "name": "Unhandled Exception",
         "func": "/**\n * Handles exceptions by extracting node details and routing them to a global logger.\n * This is designed to be called from within a Node-RED Function node or sub-flow.\n *\n * @param {Object} callingNode - The Node-RED 'this' context or msg object containing node metadata.\n * @param {Object} [callingNode.msg] - The message object associated with the error.\n * @param {Object} [callingNode.msg.error] - Error details provided by a Node-RED error catch.\n * @param {string} [callingNode.msg.error.message] - The specific error message.\n * @param {Object} [callingNode.msg.error.source] - The node that triggered the error.\n * * @example\n * // Usage in a Function Node:\n * const unhandledException = global.get('unhandledException');\n * unhandledException(this);\n */\nconst unhandledException = (callingNode) => {\n    // 1. Get the custom logger from global context\n    const log = global.get(\"logger\");\n\n    // 2. Extract error details from the msg object\n    const errorData = callingNode.msg?.error || {};\n    const errorMessage = errorData.message || \"Unknown error occurred\";\n    const sourceName = errorData.source ? (errorData.source.name || errorData.source.id) : \"Unknown Node\";\n    const sourceType = errorData.source ? errorData.source.type : \"unknown-type\";\n\n    // 3. Construct a user-friendly message for the logger\n    const friendlyMessage = `**Unhandled exception** (${sourceType} node) ${errorMessage}`;\n    callingNode.__node__ ??= {};\n    callingNode.__node__.name = sourceName;\n\n    // 4. Call the logger with level 'error'\n    // Note: the logger uses 'callingNode', we pass on whatever we have.\n    log(callingNode, friendlyMessage, 'error');\n\n};\n\nglobal.set('unhandledException', unhandledException);\n\nreturn msg;",
         "outputs": 1,
@@ -8963,10 +5015,10 @@
         ]
     },
     {
-        "id": "727b1940f24a4335",
+        "id": "b97527322a2e7dbe",
         "type": "catch",
-        "z": "48ac861af1dcedb4",
-        "g": "36ac396eb898f9cb",
+        "z": "23a4e27f08db4d94",
+        "g": "bc51ddc07489d498",
         "name": "",
         "scope": null,
         "uncaught": true,
@@ -8974,16 +5026,16 @@
         "y": 320,
         "wires": [
             [
-                "ed0ba936a7a42a23"
+                "18d96a7db7840abf"
             ]
         ],
         "l": false
     },
     {
-        "id": "ed0ba936a7a42a23",
+        "id": "18d96a7db7840abf",
         "type": "function",
-        "z": "48ac861af1dcedb4",
-        "g": "36ac396eb898f9cb",
+        "z": "23a4e27f08db4d94",
+        "g": "bc51ddc07489d498",
         "name": "Unhandled Exception",
         "func": "const handle = global.get('unhandledException');\n\nhandle(this);\n\nreturn msg;",
         "outputs": 1,
@@ -8996,30 +5048,30 @@
         "y": 320,
         "wires": [
             [
-                "2f3213f3bb3c7592"
+                "c9416ef63c9c3561"
             ]
         ],
         "l": false
     },
     {
-        "id": "2f3213f3bb3c7592",
+        "id": "c9416ef63c9c3561",
         "type": "link out",
-        "z": "48ac861af1dcedb4",
-        "g": "36ac396eb898f9cb",
+        "z": "23a4e27f08db4d94",
+        "g": "bc51ddc07489d498",
         "name": "link out 9",
         "mode": "link",
         "links": [
-            "23f62d92e226dfaf"
+            "f1d65a7781683032"
         ],
         "x": 1845,
         "y": 320,
         "wires": []
     },
     {
-        "id": "7f4cde90bcfe3341",
+        "id": "94442a5285ccfe38",
         "type": "api-current-state",
-        "z": "48ac861af1dcedb4",
-        "g": "9b07562053189234",
+        "z": "23a4e27f08db4d94",
+        "g": "d0359c3b08e2f524",
         "name": "Battery Strategy",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -9062,15 +5114,15 @@
         "y": 1140,
         "wires": [
             [
-                "70b289b6c85fb342"
+                "a4839c4b9f153153"
             ]
         ]
     },
     {
-        "id": "70b289b6c85fb342",
+        "id": "a4839c4b9f153153",
         "type": "api-current-state",
-        "z": "48ac861af1dcedb4",
-        "g": "9b07562053189234",
+        "z": "23a4e27f08db4d94",
+        "g": "d0359c3b08e2f524",
         "name": "Full Stop Trigger",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -9113,15 +5165,15 @@
         "y": 1140,
         "wires": [
             [
-                "654b3d36a54e6150"
+                "b47e86acdadefdf0"
             ]
         ]
     },
     {
-        "id": "f9c760a42193f376",
+        "id": "84caed3865b80c14",
         "type": "api-current-state",
-        "z": "48ac861af1dcedb4",
-        "g": "d32f52f0d1f5bc4f",
+        "z": "23a4e27f08db4d94",
+        "g": "d4fc23990dd3a978",
         "name": "Has import limit?",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -9164,15 +5216,15 @@
         "y": 1040,
         "wires": [
             [
-                "19ce9d0a9bcbc0ec"
+                "2f93e9d78bb9007c"
             ]
         ]
     },
     {
-        "id": "19ce9d0a9bcbc0ec",
+        "id": "2f93e9d78bb9007c",
         "type": "api-current-state",
-        "z": "48ac861af1dcedb4",
-        "g": "d32f52f0d1f5bc4f",
+        "z": "23a4e27f08db4d94",
+        "g": "d4fc23990dd3a978",
         "name": "Has export limit?",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -9215,15 +5267,15 @@
         "y": 1040,
         "wires": [
             [
-                "e37fbe205de7ccff"
+                "9868d6db22856771"
             ]
         ]
     },
     {
-        "id": "8943b2424b61435b",
+        "id": "02b5708478962713",
         "type": "function",
-        "z": "48ac861af1dcedb4",
-        "g": "829c23ac2351a872",
+        "z": "23a4e27f08db4d94",
+        "g": "c9cd464ac5e9dea8",
         "name": "Grid power",
         "func": "const log = global.get(\"logger\");\n\n// prepare grid power message\nlet state = \"measure\";\nlet ending = \"\";\nif(msg.grid_power>0) {state = \"import\"; ending = \"from grid\";}\nif(msg.grid_power<0) {state = \"export\"; ending = \"to grid\";}\nconst displayPower = Math.abs(Math.round(msg.grid_power));\n\n// explain\nlog(this, `You currently ${state} ${displayPower} W ${ending}`);\n\nreturn msg;",
         "outputs": 1,
@@ -9236,16 +5288,16 @@
         "y": 160,
         "wires": [
             [
-                "103b546ad9e1d00e"
+                "abc4f73f1f878035"
             ]
         ],
         "l": false
     },
     {
-        "id": "e37fbe205de7ccff",
+        "id": "9868d6db22856771",
         "type": "api-current-state",
-        "z": "48ac861af1dcedb4",
-        "g": "d32f52f0d1f5bc4f",
+        "z": "23a4e27f08db4d94",
+        "g": "d4fc23990dd3a978",
         "name": "Import limit",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -9288,15 +5340,15 @@
         "y": 1040,
         "wires": [
             [
-                "06f11f240d034ca7"
+                "18ccc5431a016c01"
             ]
         ]
     },
     {
-        "id": "06f11f240d034ca7",
+        "id": "18ccc5431a016c01",
         "type": "api-current-state",
-        "z": "48ac861af1dcedb4",
-        "g": "d32f52f0d1f5bc4f",
+        "z": "23a4e27f08db4d94",
+        "g": "d4fc23990dd3a978",
         "name": "Export limit",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -9339,15 +5391,15 @@
         "y": 1040,
         "wires": [
             [
-                "7f4cde90bcfe3341"
+                "94442a5285ccfe38"
             ]
         ]
     },
     {
-        "id": "c7de808391c56099",
+        "id": "4a62d45425318b8f",
         "type": "rbe",
-        "z": "48ac861af1dcedb4",
-        "g": "a6ef66efd42a9f79",
+        "z": "23a4e27f08db4d94",
+        "g": "8147fe89476d8165",
         "name": "On change",
         "func": "rbe",
         "gap": "",
@@ -9360,15 +5412,15 @@
         "y": 720,
         "wires": [
             [
-                "7f3b18cc643a32d9"
+                "0410669c44f8818b"
             ]
         ]
     },
     {
-        "id": "7f3b18cc643a32d9",
+        "id": "0410669c44f8818b",
         "type": "api-call-service",
-        "z": "48ac861af1dcedb4",
-        "g": "a6ef66efd42a9f79",
+        "z": "23a4e27f08db4d94",
+        "g": "8147fe89476d8165",
         "name": "Max usable energy",
         "server": "176d29a.6f648d6",
         "version": 7,
@@ -9397,10 +5449,10 @@
         ]
     },
     {
-        "id": "9d453126a447f823",
+        "id": "c62651c153461a9b",
         "type": "rbe",
-        "z": "48ac861af1dcedb4",
-        "g": "a6ef66efd42a9f79",
+        "z": "23a4e27f08db4d94",
+        "g": "8147fe89476d8165",
         "name": "On change",
         "func": "rbe",
         "gap": "",
@@ -9413,15 +5465,15 @@
         "y": 760,
         "wires": [
             [
-                "0f1f729af948b051"
+                "cad158ddd473ae44"
             ]
         ]
     },
     {
-        "id": "0f1f729af948b051",
+        "id": "cad158ddd473ae44",
         "type": "api-call-service",
-        "z": "48ac861af1dcedb4",
-        "g": "a6ef66efd42a9f79",
+        "z": "23a4e27f08db4d94",
+        "g": "8147fe89476d8165",
         "name": "Current power",
         "server": "176d29a.6f648d6",
         "version": 7,
@@ -9450,10 +5502,10 @@
         ]
     },
     {
-        "id": "d7b73d46113bf2da",
+        "id": "ea0955393fdf3a5a",
         "type": "rbe",
-        "z": "48ac861af1dcedb4",
-        "g": "a6ef66efd42a9f79",
+        "z": "23a4e27f08db4d94",
+        "g": "8147fe89476d8165",
         "name": "On change",
         "func": "rbe",
         "gap": "",
@@ -9466,15 +5518,15 @@
         "y": 800,
         "wires": [
             [
-                "bc76c00ced8129a4"
+                "ef996e3d84be8ca5"
             ]
         ]
     },
     {
-        "id": "bc76c00ced8129a4",
+        "id": "ef996e3d84be8ca5",
         "type": "api-call-service",
-        "z": "48ac861af1dcedb4",
-        "g": "a6ef66efd42a9f79",
+        "z": "23a4e27f08db4d94",
+        "g": "8147fe89476d8165",
         "name": "Max charging power",
         "server": "176d29a.6f648d6",
         "version": 7,
@@ -9503,10 +5555,10 @@
         ]
     },
     {
-        "id": "c4a33dedf4f3e995",
+        "id": "5e91d1e843b5bf9c",
         "type": "rbe",
-        "z": "48ac861af1dcedb4",
-        "g": "a6ef66efd42a9f79",
+        "z": "23a4e27f08db4d94",
+        "g": "8147fe89476d8165",
         "name": "On change",
         "func": "rbe",
         "gap": "",
@@ -9519,15 +5571,15 @@
         "y": 840,
         "wires": [
             [
-                "674f8659fbde7882"
+                "3f1d98c67242cdd8"
             ]
         ]
     },
     {
-        "id": "674f8659fbde7882",
+        "id": "3f1d98c67242cdd8",
         "type": "api-call-service",
-        "z": "48ac861af1dcedb4",
-        "g": "a6ef66efd42a9f79",
+        "z": "23a4e27f08db4d94",
+        "g": "8147fe89476d8165",
         "name": "Max discharging power",
         "server": "176d29a.6f648d6",
         "version": 7,
@@ -9556,9 +5608,9 @@
         ]
     },
     {
-        "id": "9d862d9e9136e191",
+        "id": "6236b1eaca325c8d",
         "type": "debug",
-        "z": "48ac861af1dcedb4",
+        "z": "23a4e27f08db4d94",
         "name": "Check totals",
         "active": false,
         "tosidebar": true,
@@ -9573,25 +5625,25 @@
         "wires": []
     },
     {
-        "id": "e4eccc0b9ca0a9dc",
+        "id": "af36a06160da45e1",
         "type": "link in",
-        "z": "dfa0cbce6ff0c1a2",
-        "g": "6c719ad1b1b5d932",
+        "z": "889df07ac7f6b084",
+        "g": "a365917b24c83755",
         "name": "Charge PV",
         "links": [],
         "x": 100,
         "y": 160,
         "wires": [
             [
-                "51cfba29204ad7ff"
+                "e57e883f7be479bc"
             ]
         ],
         "l": true
     },
     {
-        "id": "a7500d0440142605",
+        "id": "484c8cb34e698a65",
         "type": "comment",
-        "z": "dfa0cbce6ff0c1a2",
+        "z": "889df07ac7f6b084",
         "name": "Home Battery Strategy",
         "info": "The `Home Battery Start` flow will call this strategy flow\nby matching the strategy name with the Link In name.\n\nConfigure the Link In node in the Start group.\n\nDon't modify other parts of the Start and End groups.\nThey handle the calling and returning for you.",
         "x": 120,
@@ -9599,10 +5651,10 @@
         "wires": []
     },
     {
-        "id": "ac182b81fae26bdb",
+        "id": "64795d59800fc62f",
         "type": "comment",
-        "z": "dfa0cbce6ff0c1a2",
-        "g": "6c719ad1b1b5d932",
+        "z": "889df07ac7f6b084",
+        "g": "a365917b24c83755",
         "name": "Start (readme)",
         "info": "# Setting up your battery strategy flow\n\n## Setup\nName the `Link In node` in this start group exactly after the <select> option configured in your\nselect_input.house_battery_strategy\n\nconfigure select options in:\ninput_select_house_battery_control.yaml\n\n### example\n`house_battery_strategy:\n  name: House Battery Strategy\n  options:\n    - AcmE example`\n\nThe above creates a select option, allowing user to select 'AcmE example'\n\nWhen selected, battery control will search for a flow containing a Link In node\ncalled 'AcmE example' (case sensitive).",
         "x": 110,
@@ -9610,10 +5662,10 @@
         "wires": []
     },
     {
-        "id": "94e7b2a834260f5e",
+        "id": "3421fa0a5a803b53",
         "type": "link out",
-        "z": "dfa0cbce6ff0c1a2",
-        "g": "72219ac095fb2ca7",
+        "z": "889df07ac7f6b084",
+        "g": "d12e7189dbb4a8c1",
         "name": "Return",
         "mode": "return",
         "links": [],
@@ -9622,10 +5674,10 @@
         "wires": []
     },
     {
-        "id": "181c689ab3b8d58b",
+        "id": "e74410daf9280ceb",
         "type": "comment",
-        "z": "dfa0cbce6ff0c1a2",
-        "g": "72219ac095fb2ca7",
+        "z": "889df07ac7f6b084",
+        "g": "d12e7189dbb4a8c1",
         "name": "End (readme)",
         "info": "Should return a solution_array of battery objects\n\n## battery object format\n`{{id: string|number, mode: string, power: number}} battery solution`\n- id is an arbitrary battery ID\n- mode is \"stop\", \"charge\", \"discharge\" for Marstek\n- power in Watts\n\n### example array\nreturn this type of solution_array via msg.solutions\n` \nlet solution_array = [];\nsolution_array.push({id:\"M1\", mode: \"charge\", power: 100}); // per battery\nreturn {solutions: solution_array};\n` ",
         "x": 1280,
@@ -9633,10 +5685,10 @@
         "wires": []
     },
     {
-        "id": "920de7de0f4325f6",
+        "id": "44dc3499d20d0627",
         "type": "function",
-        "z": "dfa0cbce6ff0c1a2",
-        "g": "9567cf44eb70463d",
+        "z": "889df07ac7f6b084",
+        "g": "d9f0bc2a9b86a02c",
         "name": "Charge PV",
         "func": "// explain\nconst log = global.get(\"logger\");\nlog(this,\"Using `Self-consumption` to charge with surplus PV\")\n\n// use the self consumption strategy to charge when there is PV surplus\nmsg.target = \"Self-consumption\";\n\n// tell that strategy to disallow discharging\nconst DISCHARGE_DISABLED = true;\nRED.util.setMessageProperty(msg,\"advanced_settings.discharge_disabled\",DISCHARGE_DISABLED,true);\n\nreturn msg;",
         "outputs": 1,
@@ -9649,15 +5701,15 @@
         "y": 160,
         "wires": [
             [
-                "52a273930dbe024b"
+                "a5a1152348357755"
             ]
         ]
     },
     {
-        "id": "52a273930dbe024b",
+        "id": "a5a1152348357755",
         "type": "link call",
-        "z": "dfa0cbce6ff0c1a2",
-        "g": "9567cf44eb70463d",
+        "z": "889df07ac7f6b084",
+        "g": "d9f0bc2a9b86a02c",
         "name": "Self-consumption",
         "links": [],
         "linkType": "dynamic",
@@ -9666,15 +5718,15 @@
         "y": 160,
         "wires": [
             [
-                "94e7b2a834260f5e"
+                "3421fa0a5a803b53"
             ]
         ]
     },
     {
-        "id": "51cfba29204ad7ff",
+        "id": "e57e883f7be479bc",
         "type": "change",
-        "z": "dfa0cbce6ff0c1a2",
-        "g": "6c719ad1b1b5d932",
+        "z": "889df07ac7f6b084",
+        "g": "a365917b24c83755",
         "name": "Trace",
         "rules": [
             {
@@ -9694,16 +5746,16 @@
         "y": 200,
         "wires": [
             [
-                "b6e5dd5b0a26b72a"
+                "9b8669c49735f50b"
             ]
         ],
         "info": "Attaches a breadcrumb trace to the msg\r\nso the user can reconstruct which route has\r\nbeen traveled"
     },
     {
-        "id": "39d704a68513bd47",
+        "id": "4f8432f0d078b6ee",
         "type": "catch",
-        "z": "dfa0cbce6ff0c1a2",
-        "g": "4de60a2978bb51c9",
+        "z": "889df07ac7f6b084",
+        "g": "55ecd7da708b2bd4",
         "name": "",
         "scope": null,
         "uncaught": false,
@@ -9711,16 +5763,16 @@
         "y": 300,
         "wires": [
             [
-                "26fda02e6fa0fe69"
+                "b4acc2524c25a0e8"
             ]
         ],
         "l": false
     },
     {
-        "id": "26fda02e6fa0fe69",
+        "id": "b4acc2524c25a0e8",
         "type": "function",
-        "z": "dfa0cbce6ff0c1a2",
-        "g": "4de60a2978bb51c9",
+        "z": "889df07ac7f6b084",
+        "g": "55ecd7da708b2bd4",
         "name": "Unhandled Exception",
         "func": "const handle = global.get('unhandledException');\n\nhandle(this);\n\nreturn msg;",
         "outputs": 1,
@@ -9733,16 +5785,16 @@
         "y": 300,
         "wires": [
             [
-                "dfa93e91042443de"
+                "40fd2cc4ce71f0ca"
             ]
         ],
         "l": false
     },
     {
-        "id": "dfa93e91042443de",
+        "id": "40fd2cc4ce71f0ca",
         "type": "link out",
-        "z": "dfa0cbce6ff0c1a2",
-        "g": "4de60a2978bb51c9",
+        "z": "889df07ac7f6b084",
+        "g": "55ecd7da708b2bd4",
         "name": "link out 4",
         "mode": "return",
         "links": [],
@@ -9751,9 +5803,9 @@
         "wires": []
     },
     {
-        "id": "b6e5dd5b0a26b72a",
+        "id": "9b8669c49735f50b",
         "type": "function",
-        "z": "dfa0cbce6ff0c1a2",
+        "z": "889df07ac7f6b084",
         "name": "Mode selection",
         "func": "/* Mode selection \n * \n * Peak shaving can be triggered by:\n * - Grid power exceeds the import/export limit set by the user\n * \n * Peak shaving will persist while:\n * - Grid power exceeds the import/export limit set by the user\n * - Batteries are applied to keep system below the limit set by the user\n * \n * The first is checked in this node.\n * The latter is checked in the last function node of the Peak Shaving flow.\n * Both set the `last_power_limit_violation` flow variable to Date.now() to persist peak shaving.\n * \n * PEAK_SHAVING_TIMEOUT_SEC is advised to be kept above atleast 3-5 seconds, to account for rate limiters and other power saving options.\n*/\n\n// Timestamp\nconst now = Date.now();\n\n// Logger\nconst log = global.get(\"logger\");\n\n// Configuration & State recovery\nconst PEAK_SHAVING_TIMEOUT_SEC = 10;\nlet isPeakShaving = flow.get(\"is_peak_shaving\") ?? false;\nlet lastPowerLimitViolation = flow.get(\"last_power_limit_violation\") ?? now;\nlet isPowerLimitViolation = false;\n\n// Input Data\nconst hasImportLimit = RED.util.getMessageProperty(msg, \"grid_power_has_limit_import\") || false;\nconst importLimit = parseInt(RED.util.getMessageProperty(msg, \"grid_power_limit_import\") || 0);\nconst P1_power = parseInt(RED.util.getMessageProperty(msg, \"grid_power\") || 0);\n\n// ACTIVATE shaving\nif (hasImportLimit && (P1_power > importLimit)) {\n    isPeakShaving = true;\n    isPowerLimitViolation = true;\n}\n\n// UPDATE timer or continue\nif (isPowerLimitViolation) lastPowerLimitViolation = now;\n\n// CALCULATE release logic\n// Seconds since the last time the power limit was exceeded\nlet secondsSinceLastViolation = Math.floor((now - lastPowerLimitViolation) / 1000);\n\n// RELEASE shaving logic\n// Only release if we are currently shaving AND the timeout has passed\nif (isPeakShaving && (secondsSinceLastViolation >= PEAK_SHAVING_TIMEOUT_SEC)) {\n    isPeakShaving = false;\n    log(this,\"Peak Shaving released, resume normal operation\");\n}\n\n// UI & OUTPUT Logic\nif (isPeakShaving) {\n    // Timeout progress\n    const secondsRemaining = PEAK_SHAVING_TIMEOUT_SEC - secondsSinceLastViolation;\n    // Set grid power limit\n    msg.payload = importLimit;\n    // UI\n    node.status({\n        fill: \"yellow\",\n        shape: \"dot\",\n        text: isPowerLimitViolation ? `Peak Shaving` :`Peak Shaving: release in ${secondsRemaining}s`\n    });\n} else {\n    // UI\n    node.status({\n        fill: \"green\",\n        shape: \"dot\",\n        text: \"Grid OK - Charging PV\"\n    });\n}\n\n// Persist state for next run\nflow.set(\"is_peak_shaving\", isPeakShaving); \nif (isPowerLimitViolation) flow.set(\"last_power_limit_violation\", now); // Power limit exceeded. Update the lastPowerLimitViolation timestamp to current time\n\n// Finalize msg\nRED.util.setMessageProperty(msg, \"strategy.is_peak_shaving\", isPeakShaving, true);\n\n// OUTPUT\nreturn msg;",
         "outputs": 1,
@@ -9766,14 +5818,14 @@
         "y": 200,
         "wires": [
             [
-                "6664ad6a207ee9f0"
+                "deddcac2f2fad63e"
             ]
         ]
     },
     {
-        "id": "6664ad6a207ee9f0",
+        "id": "deddcac2f2fad63e",
         "type": "switch",
-        "z": "dfa0cbce6ff0c1a2",
+        "z": "889df07ac7f6b084",
         "name": "Operating mode",
         "property": "strategy.is_peak_shaving",
         "propertyType": "msg",
@@ -9792,18 +5844,18 @@
         "y": 200,
         "wires": [
             [
-                "920de7de0f4325f6"
+                "44dc3499d20d0627"
             ],
             [
-                "06b33ef774980631"
+                "f24d62ee3f778ac5"
             ]
         ]
     },
     {
-        "id": "06b33ef774980631",
+        "id": "f24d62ee3f778ac5",
         "type": "function",
-        "z": "dfa0cbce6ff0c1a2",
-        "g": "38bba18f3d579ec7",
+        "z": "889df07ac7f6b084",
+        "g": "f9bc47ded21ba4df",
         "name": "Peak shaving",
         "func": "// Logger\nconst log = global.get(\"logger\");\n\n// Explain\nlog(this,`**Peak shaving mode** postponing '${msg.target}' strategy`);\n\n// Use the PID controller strategy\nmsg.target = \"Self-consumption\";\n// Set the grid power limit\nmsg.house_target_grid_consumption_in_w = msg.payload;\n// Tell the strategy to discharging only\nconst CHARGE_DISABLED = true;\nRED.util.setMessageProperty(msg, \"advanced_settings.charge_disabled\", CHARGE_DISABLED, true);\n\nreturn msg;",
         "outputs": 1,
@@ -9816,15 +5868,15 @@
         "y": 260,
         "wires": [
             [
-                "ae35dc57dde4e6e6"
+                "186720c4c21e4f7c"
             ]
         ]
     },
     {
-        "id": "ae35dc57dde4e6e6",
+        "id": "186720c4c21e4f7c",
         "type": "link call",
-        "z": "dfa0cbce6ff0c1a2",
-        "g": "38bba18f3d579ec7",
+        "z": "889df07ac7f6b084",
+        "g": "f9bc47ded21ba4df",
         "name": "Self-consumption",
         "links": [],
         "linkType": "dynamic",
@@ -9833,15 +5885,15 @@
         "y": 260,
         "wires": [
             [
-                "b3560dc235a3bf07"
+                "ca4151ce7a16368c"
             ]
         ]
     },
     {
-        "id": "b3560dc235a3bf07",
+        "id": "ca4151ce7a16368c",
         "type": "function",
-        "z": "dfa0cbce6ff0c1a2",
-        "g": "38bba18f3d579ec7",
+        "z": "889df07ac7f6b084",
+        "g": "f9bc47ded21ba4df",
         "name": "Peak check",
         "func": "// Logger\nconst log = global.get(\"logger\");\n\n// INPUT\nconst PID_assigned = msg.pid?.load_assigned ?? 0; // calculated battery power delivery, see footnote_1 why this is 0 by default\nconst isCharging = msg.batteries_charging || false;\n\n// HOLD peak shave when:\nif(PID_assigned > 0 && !isCharging) {\n    // The batteries are still required to reduce the power peak\n    log(this,`**Peak shaving continues**, batteries still required for peak reduction`);\n    // Reset timeout timer\n    flow.set(\"last_power_limit_violation\", Date.now()); \n    // UI\n    node.status({fill:\"yellow\",shape:\"dot\",text:`Holding peak shave, batteries still required for ${PID_assigned} W`});\n} else {\n    // No solution or batteries not required - let timer run out\n    node.status({fill:\"green\",shape:\"dot\",text:`Relax`});\n}\n\nreturn msg;\n\n// FOOTNOTE_1: \n// Self-consumption won't return `msg.solutions` nor `msg.pid.load_assigned` when:\n// - P1 is near or at it's target grid consumption (aka inside deadband)\n// - when a non-blocking error occurs\n// \n// This code does not specifically account for these cases, but applies a TIMEOUT mechanism instead.\n// As PID_assigned is kept 0, the timer won't be updated and runs out.",
         "outputs": 1,
@@ -9854,14 +5906,14 @@
         "y": 260,
         "wires": [
             [
-                "94e7b2a834260f5e"
+                "3421fa0a5a803b53"
             ]
         ]
     },
     {
-        "id": "775e7d205f2b5489",
+        "id": "6bf07c3a4ef449d8",
         "type": "comment",
-        "z": "ea282c9a1916db76",
+        "z": "d60f98965bf0409c",
         "name": "Home Battery Strategy",
         "info": "The `Home Battery Start` flow will call this strategy flow\nby matching the strategy name with the Link In name.\n\nConfigure the Link In node in the Start group.\n\nDon't modify other parts of the Start and End groups.\nThey handle the calling and returning for you.",
         "x": 140,
@@ -9869,26 +5921,26 @@
         "wires": []
     },
     {
-        "id": "b3b3227d475762d3",
+        "id": "ba76c6477e7a8718",
         "type": "link in",
-        "z": "ea282c9a1916db76",
-        "g": "e83ca9894fafba83",
+        "z": "d60f98965bf0409c",
+        "g": "3b30db19a6d0a9b0",
         "name": "Charge",
         "links": [],
         "x": 110,
         "y": 220,
         "wires": [
             [
-                "60609e6c410aadc2"
+                "7b2476fe325113b4"
             ]
         ],
         "l": true
     },
     {
-        "id": "193129d79e10395b",
+        "id": "2b775c4b3fc7a4d6",
         "type": "comment",
-        "z": "ea282c9a1916db76",
-        "g": "e83ca9894fafba83",
+        "z": "d60f98965bf0409c",
+        "g": "3b30db19a6d0a9b0",
         "name": "Start (readme)",
         "info": "# Setting up your battery strategy flow\n\n## Setup\nName the `Link In node` in this start group exactly after the <select> option configured in your\nselect_input.house_battery_strategy\n\nconfigure select options in:\ninput_select_house_battery_control.yaml\n\n### example\n`house_battery_strategy:\n  name: House Battery Strategy\n  options:\n    - AcmE example`\n\nThe above creates a select option, allowing user to select 'AcmE example'\n\nWhen selected, battery control will search for a flow containing a Link In node\ncalled 'AcmE example' (case sensitive).",
         "x": 130,
@@ -9896,10 +5948,10 @@
         "wires": []
     },
     {
-        "id": "60609e6c410aadc2",
+        "id": "7b2476fe325113b4",
         "type": "change",
-        "z": "ea282c9a1916db76",
-        "g": "e83ca9894fafba83",
+        "z": "d60f98965bf0409c",
+        "g": "3b30db19a6d0a9b0",
         "name": "Trace",
         "rules": [
             {
@@ -9919,16 +5971,16 @@
         "y": 180,
         "wires": [
             [
-                "123af548fb46d3fc"
+                "60818973c652a28b"
             ]
         ],
         "info": "Attaches a breadcrumb trace to the msg\r\nso the user can reconstruct which route has\r\nbeen traveled"
     },
     {
-        "id": "0a3bdc2aa08626d5",
+        "id": "2c94e4382f2869ca",
         "type": "link out",
-        "z": "ea282c9a1916db76",
-        "g": "6f5226c3d3419e05",
+        "z": "d60f98965bf0409c",
+        "g": "c6b82dc737e918bc",
         "name": "Return",
         "mode": "return",
         "links": [],
@@ -9937,10 +5989,10 @@
         "wires": []
     },
     {
-        "id": "09cd251a8a1c8ed2",
+        "id": "64bcf1f04dbbd6f5",
         "type": "comment",
-        "z": "ea282c9a1916db76",
-        "g": "6f5226c3d3419e05",
+        "z": "d60f98965bf0409c",
+        "g": "c6b82dc737e918bc",
         "name": "End (readme)",
         "info": "Should return a solution_array of battery objects\n\n## battery object format\n`{{id: string|number, mode: string, power: number}} battery solution`\n- id is an arbitrary battery ID\n- mode is \"stop\", \"charge\", \"discharge\" for Marstek\n- power in Watts\n\n### example array\nreturn this type of solution_array via msg.solutions\n` \nlet solution_array = [];\nsolution_array.push({id:\"M1\", mode: \"charge\", power: 100}); // per battery\nreturn {solutions: solution_array};\n` ",
         "x": 130,
@@ -9948,29 +6000,29 @@
         "wires": []
     },
     {
-        "id": "fcd9a95f1b45497c",
+        "id": "9af5a7904623a82e",
         "type": "link in",
-        "z": "ea282c9a1916db76",
-        "g": "6f5226c3d3419e05",
+        "z": "d60f98965bf0409c",
+        "g": "c6b82dc737e918bc",
         "name": "link to End",
         "links": [
-            "a6b5d382cfe059f7",
-            "92cf91937116658c",
-            "3f16ffc073bb4b4a"
+            "1e568d834ff1e000",
+            "f226f40f1a8f6d50",
+            "f96d862ec3b2ecbf"
         ],
         "x": 75,
         "y": 680,
         "wires": [
             [
-                "0a3bdc2aa08626d5"
+                "2c94e4382f2869ca"
             ]
         ]
     },
     {
-        "id": "d5538c7d757428cd",
+        "id": "766cb40ec6f263ae",
         "type": "function",
-        "z": "ea282c9a1916db76",
-        "g": "ca7cdbd7beb12727",
+        "z": "d60f98965bf0409c",
+        "g": "ceed73f8bc60e712",
         "name": "Max power solution",
         "func": "// Logger, usage: log(this, \"\");\nconst log = global.get('logger');\nlog(this, \"Charge at **max. power**\");\n\n// INPUT\nlet batteries = msg.batteries;\nlet solution_array = [];\n\n// build solution\nmsg.batteries.forEach(battery => {\n    const calculatedPower = Number(battery.charging_max);\n\n    solution_array.push({\n        id: battery.id,\n        mode: \"charge\",\n        power: calculatedPower\n    });\n\n});\n\n// return solution\nmsg.solutions = solution_array;\nreturn msg;",
         "outputs": 1,
@@ -9983,15 +6035,15 @@
         "y": 580,
         "wires": [
             [
-                "e8e9a2482984ece2"
+                "f220de39e40f2d8f"
             ]
         ]
     },
     {
-        "id": "21d353fbb79bab65",
+        "id": "d8dcda2cbc3cc00e",
         "type": "link call",
-        "z": "ea282c9a1916db76",
-        "g": "ca7cdbd7beb12727",
+        "z": "d60f98965bf0409c",
+        "g": "ceed73f8bc60e712",
         "name": "Call flow",
         "links": [],
         "linkType": "dynamic",
@@ -10000,16 +6052,16 @@
         "y": 620,
         "wires": [
             [
-                "75ba44f750bf1408",
-                "3f16ffc073bb4b4a"
+                "9ce7a9d690018b01",
+                "f96d862ec3b2ecbf"
             ]
         ]
     },
     {
-        "id": "cc62b37cec0aca75",
+        "id": "834eed358b3d0661",
         "type": "switch",
-        "z": "ea282c9a1916db76",
-        "g": "ca7cdbd7beb12727",
+        "z": "d60f98965bf0409c",
+        "g": "ceed73f8bc60e712",
         "name": "Import at max power",
         "property": "grid_power_has_limit_import",
         "propertyType": "msg",
@@ -10028,18 +6080,18 @@
         "y": 600,
         "wires": [
             [
-                "d5538c7d757428cd"
+                "766cb40ec6f263ae"
             ],
             [
-                "75c6eae8657baf3f"
+                "d7a854b56b45db65"
             ]
         ]
     },
     {
-        "id": "75ba44f750bf1408",
+        "id": "9ce7a9d690018b01",
         "type": "debug",
-        "z": "ea282c9a1916db76",
-        "g": "ca7cdbd7beb12727",
+        "z": "d60f98965bf0409c",
+        "g": "ceed73f8bc60e712",
         "name": "Regulated",
         "active": true,
         "tosidebar": false,
@@ -10054,10 +6106,10 @@
         "wires": []
     },
     {
-        "id": "71822aeb406c67b9",
+        "id": "f6444602754619c5",
         "type": "debug",
-        "z": "ea282c9a1916db76",
-        "g": "ca7cdbd7beb12727",
+        "z": "d60f98965bf0409c",
+        "g": "ceed73f8bc60e712",
         "name": "Maximum",
         "active": true,
         "tosidebar": false,
@@ -10072,10 +6124,10 @@
         "wires": []
     },
     {
-        "id": "75c6eae8657baf3f",
+        "id": "d7a854b56b45db65",
         "type": "function",
-        "z": "ea282c9a1916db76",
-        "g": "ca7cdbd7beb12727",
+        "z": "d60f98965bf0409c",
+        "g": "ceed73f8bc60e712",
         "name": "Regulated power",
         "func": "// Logger, usage: log(this, \"\");\nconst log = global.get('logger');\n\n// Which sub-strategy to use\nmsg.target = \"Self-consumption\";\n\n// Grid power limit\nconst targetGridPower = parseInt(msg.grid_power_limit_import);\n\n// Set target grid consumption for the PID controller\nmsg.house_target_grid_consumption_in_w = targetGridPower;\n// tell PID to avoid discharge solutions during charging.\nRED.util.setMessageProperty(msg,\"advanced_settings.discharge_disabled\",true,true);\n\n// Finally\nlog(this, `**Regulated** charging. Target grid power: ${Math.floor(targetGridPower)} W`);\nreturn msg;",
         "outputs": 1,
@@ -10088,15 +6140,15 @@
         "y": 620,
         "wires": [
             [
-                "21d353fbb79bab65"
+                "d8dcda2cbc3cc00e"
             ]
         ]
     },
     {
-        "id": "e8e9a2482984ece2",
+        "id": "f220de39e40f2d8f",
         "type": "change",
-        "z": "ea282c9a1916db76",
-        "g": "ca7cdbd7beb12727",
+        "z": "d60f98965bf0409c",
+        "g": "ceed73f8bc60e712",
         "name": "Continue",
         "rules": [
             {
@@ -10116,20 +6168,20 @@
         "y": 580,
         "wires": [
             [
-                "71822aeb406c67b9",
-                "3f16ffc073bb4b4a"
+                "f6444602754619c5",
+                "f96d862ec3b2ecbf"
             ]
         ]
     },
     {
-        "id": "3f16ffc073bb4b4a",
+        "id": "f96d862ec3b2ecbf",
         "type": "link out",
-        "z": "ea282c9a1916db76",
-        "g": "ca7cdbd7beb12727",
+        "z": "d60f98965bf0409c",
+        "g": "ceed73f8bc60e712",
         "name": "go to End",
         "mode": "link",
         "links": [
-            "fcd9a95f1b45497c"
+            "9af5a7904623a82e"
         ],
         "x": 960,
         "y": 680,
@@ -10137,10 +6189,10 @@
         "l": true
     },
     {
-        "id": "d3c73a6dca461f97",
+        "id": "eb7b9310b7255bf1",
         "type": "function",
-        "z": "ea282c9a1916db76",
-        "g": "1b9d9a2cb683bbba",
+        "z": "d60f98965bf0409c",
+        "g": "3864eee6ef12a6cf",
         "name": "Unknown -> Full stop",
         "func": "const log = global.get(\"logger\");\n\n// Unkown export goal\nlog(this, `**${msg.charge.goal}**; Charge goal not recognized. Fallback to **Full Stop**`,\"warn\");\n\n// Full stop\nmsg.target = \"Full stop\";\n\nreturn msg;",
         "outputs": 1,
@@ -10153,15 +6205,15 @@
         "y": 260,
         "wires": [
             [
-                "2a6d963285cea2ba"
+                "58ef2462a9398e6d"
             ]
         ]
     },
     {
-        "id": "2a6d963285cea2ba",
+        "id": "58ef2462a9398e6d",
         "type": "link call",
-        "z": "ea282c9a1916db76",
-        "g": "1b9d9a2cb683bbba",
+        "z": "d60f98965bf0409c",
+        "g": "3864eee6ef12a6cf",
         "name": "Call flow",
         "links": [],
         "linkType": "dynamic",
@@ -10170,15 +6222,15 @@
         "y": 260,
         "wires": [
             [
-                "a6b5d382cfe059f7"
+                "1e568d834ff1e000"
             ]
         ]
     },
     {
-        "id": "cbc44637fd9c21e8",
+        "id": "03a2451155697047",
         "type": "api-current-state",
-        "z": "ea282c9a1916db76",
-        "g": "1b9d9a2cb683bbba",
+        "z": "d60f98965bf0409c",
+        "g": "3864eee6ef12a6cf",
         "name": "Energy reserve hi",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -10221,19 +6273,19 @@
         "y": 180,
         "wires": [
             [
-                "21c2b3f683139a28"
+                "b7d4d7c413086e23"
             ]
         ]
     },
     {
-        "id": "a6b5d382cfe059f7",
+        "id": "1e568d834ff1e000",
         "type": "link out",
-        "z": "ea282c9a1916db76",
-        "g": "1b9d9a2cb683bbba",
+        "z": "d60f98965bf0409c",
+        "g": "3864eee6ef12a6cf",
         "name": "go to End",
         "mode": "link",
         "links": [
-            "fcd9a95f1b45497c"
+            "9af5a7904623a82e"
         ],
         "x": 1220,
         "y": 260,
@@ -10241,10 +6293,10 @@
         "l": true
     },
     {
-        "id": "08e66a7a4d5aee4b",
+        "id": "aeeffc28ca9116e3",
         "type": "api-current-state",
-        "z": "ea282c9a1916db76",
-        "g": "1b9d9a2cb683bbba",
+        "z": "d60f98965bf0409c",
+        "g": "3864eee6ef12a6cf",
         "name": "SoC reached",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -10287,15 +6339,15 @@
         "y": 140,
         "wires": [
             [
-                "364b6da4bebb7353"
+                "35ca58c8f870157c"
             ]
         ]
     },
     {
-        "id": "21c2b3f683139a28",
+        "id": "b7d4d7c413086e23",
         "type": "function",
-        "z": "ea282c9a1916db76",
-        "g": "1b9d9a2cb683bbba",
+        "z": "d60f98965bf0409c",
+        "g": "3864eee6ef12a6cf",
         "name": "Check if hi",
         "func": "// 1. Get the custom logger from global context\nconst log = global.get(\"logger\");\nlog(this,`Charge until: ${msg.charge.goal}`);\n\n// 2. Extract energy level from msg (default to 0 if property is missing)\nconst energy_remaining = Number(RED.util.getMessageProperty(msg, \"batteries_available_energy\")) || 0;\nvar energy_threshold = Number(RED.util.getMessageProperty(msg,\"charge.threshold_energy\"));\nif (energy_threshold === undefined || energy_threshold <= 0){\n    log(this,`Desired energy reserve invalid '${energy_threshold}' kWh. I've set it to ${Number(msg.batteries_max_energy).toFixed(1)} kWh`,\"warn\");\n    energy_threshold = Math.floor(Number(msg.batteries_max_energy)*10)/10;\n}\n\n// 3. Logic: Determine if energy level is at or below zero\nif (energy_remaining >= energy_threshold) {\n    msg.charge.threshold_reached = true;\n    \n    // User friendly feedback via the custom logger\n    log(this, `[STOP] Energy reserve at ${energy_remaining.toFixed(1)} / ${energy_threshold.toFixed(1)} kWh`, 'info');\n} else {\n    msg.charge.threshold_reached = false;\n    \n    // User friendly feedback via the custom logger\n    log(this, `[OK] Energy reserve at ${energy_remaining.toFixed(1)} / ${energy_threshold.toFixed(1)} kWh.`, 'info');\n}\n\n// 4. Update node status for visual feedback in the editor\nnode.status({ \n    fill: msg.charge.threshold_reached ? \"red\" : \"green\", \n    shape: \"dot\", \n    text: `Threshold reached: ${msg.charge.threshold_reached}` \n});\n\nreturn msg;",
         "outputs": 1,
@@ -10308,16 +6360,16 @@
         "y": 180,
         "wires": [
             [
-                "965ec6679352d78f",
-                "1e5222f2eac079b6"
+                "01b253901b25116d",
+                "cc30a0b748b12089"
             ]
         ]
     },
     {
-        "id": "364b6da4bebb7353",
+        "id": "35ca58c8f870157c",
         "type": "function",
-        "z": "ea282c9a1916db76",
-        "g": "1b9d9a2cb683bbba",
+        "z": "d60f98965bf0409c",
+        "g": "3864eee6ef12a6cf",
         "name": "Check if SoC",
         "func": "// 1. Get the custom logger from global context\nconst log = global.get(\"logger\");\nlog(this, `Charge until: ${msg.charge.goal}`);\n\n// 2. Extract average SoC and desired SoC level\nlet batteries = msg.batteries;\nlet soc_avg = 0;\nlet count = 0; // could use msg.battery_count\nbatteries.forEach(battery => {\n    soc_avg += battery.soc;\n    count++;\n});\n// 2.1 Current avg. SoC\nsoc_avg = Math.round(soc_avg / count * 100) / 100;\n// 2.2 Charge until SoC (100% as fallback)\nvar soc_threshold = Number(RED.util.getMessageProperty(msg,\"charge.threshold_soc\"));\nif (soc_threshold === undefined || soc_threshold < 11){\n    log(this, `Desired SoC not set correctly '${soc_threshold}' %. I've set it to 100%.`,\"warn\");\n    soc_threshold = 100;\n}\n\n// 3. Logic: Determine if SoC level is at or above desired level\nif (soc_avg >= soc_threshold) {\n    msg.charge.threshold_reached = true;\n\n    // User friendly feedback via the custom logger\n    log(this, `[STOP] Average SoC at ${soc_avg.toFixed(1)}/${soc_threshold.toFixed(1)} %.`, 'info');\n} else {\n    msg.charge.threshold_reached = false;\n\n    // User friendly feedback via the custom logger\n    log(this, `[OK] Average SoC at ${soc_avg.toFixed(1)}/${soc_threshold.toFixed(1)} %.`, 'info');\n}\n\n// 4. Update node status for visual feedback in the editor\nnode.status({\n    fill: msg.charge.threshold_reached ? \"red\" : \"green\",\n    shape: \"dot\",\n    text: `Threshold reached: ${msg.charge.threshold_reached}`\n});\n\nreturn msg;",
         "outputs": 1,
@@ -10330,15 +6382,15 @@
         "y": 140,
         "wires": [
             [
-                "965ec6679352d78f"
+                "01b253901b25116d"
             ]
         ]
     },
     {
-        "id": "a97682586d7a8650",
+        "id": "2e79cc6f7e5fd376",
         "type": "change",
-        "z": "ea282c9a1916db76",
-        "g": "1b9d9a2cb683bbba",
+        "z": "d60f98965bf0409c",
+        "g": "3864eee6ef12a6cf",
         "name": "Batteries are full",
         "rules": [
             {
@@ -10358,15 +6410,15 @@
         "y": 100,
         "wires": [
             [
-                "eedd3c5e056e808c"
+                "3bb859cb9b639ffa"
             ]
         ]
     },
     {
-        "id": "eedd3c5e056e808c",
+        "id": "3bb859cb9b639ffa",
         "type": "function",
-        "z": "ea282c9a1916db76",
-        "g": "1b9d9a2cb683bbba",
+        "z": "d60f98965bf0409c",
+        "g": "3864eee6ef12a6cf",
         "name": "Check if full",
         "func": "// 1. Get the custom logger from global context\nconst log = global.get(\"logger\");\nlog(this,`Charge until: ${msg.charge.goal}`);\n\n// 2. Extract energy level from msg (and handle missing properties)\nconst energy_remaining = Number(RED.util.getMessageProperty(msg, \"batteries_available_energy\")) || 0;\nconst energy_max = Number(RED.util.getMessageProperty(msg, \"batteries_max_energy\")) || 0;\nif(energy_max == 0) log(this,`Batteries max energy missing! ${msg.batteries_max_energy}`);\n// 2.1 Check if every battery's SoC is at or over the max\nconst isAtMax = msg.batteries.every(battery => battery.soc >= battery.soc_max);\n\n// 3. Logic: Determine if energy level is over or near 99.9% of max eneregy\nif (isAtMax) {\n    msg.charge.threshold_reached = true;\n    \n    // User friendly feedback via the custom logger\n    log(this, `[STOP] All batteries are full or at SoC_max_ (${energy_remaining} kWh).`, 'info');\n} else {\n    msg.charge.threshold_reached = false;\n    \n    // User friendly feedback via the custom logger\n    log(this, `[OK] Battery level ${energy_remaining.toFixed(2)} kWh below ${energy_max.toFixed(2)} kWh.`, 'info');\n}\n\n// 4. Update node status for visual feedback in the editor\nnode.status({ \n    fill: msg.charge.threshold_reached ? \"red\" : \"green\", \n    shape: \"dot\", \n    text: `Threshold reached: ${msg.charge.threshold_reached}` \n});\n\nreturn msg;",
         "outputs": 1,
@@ -10379,15 +6431,15 @@
         "y": 100,
         "wires": [
             [
-                "965ec6679352d78f"
+                "01b253901b25116d"
             ]
         ]
     },
     {
-        "id": "b08d963419a0ef8f",
+        "id": "66e598d1b9d621b8",
         "type": "switch",
-        "z": "ea282c9a1916db76",
-        "g": "1b9d9a2cb683bbba",
+        "z": "d60f98965bf0409c",
+        "g": "3864eee6ef12a6cf",
         "name": "Until reached",
         "property": "charge.threshold_reached",
         "propertyType": "msg",
@@ -10406,18 +6458,18 @@
         "y": 140,
         "wires": [
             [
-                "2649315e8c01a01b"
+                "3434f8046ace9f46"
             ],
             [
-                "2b2df59d717f740d"
+                "1eae51cada2081bf"
             ]
         ]
     },
     {
-        "id": "2649315e8c01a01b",
+        "id": "3434f8046ace9f46",
         "type": "function",
-        "z": "ea282c9a1916db76",
-        "g": "1b9d9a2cb683bbba",
+        "z": "d60f98965bf0409c",
+        "g": "3864eee6ef12a6cf",
         "name": "Yes -> Charge PV",
         "func": "// If any solar surplus remains, soak it up instead of waiting in Full stop.\nmsg.target = \"Charge PV\";\nreturn msg;",
         "outputs": 1,
@@ -10430,15 +6482,15 @@
         "y": 100,
         "wires": [
             [
-                "913c7c41126b2a95"
+                "8ef70b102d3efa7b"
             ]
         ]
     },
     {
-        "id": "913c7c41126b2a95",
+        "id": "8ef70b102d3efa7b",
         "type": "link call",
-        "z": "ea282c9a1916db76",
-        "g": "1b9d9a2cb683bbba",
+        "z": "d60f98965bf0409c",
+        "g": "3864eee6ef12a6cf",
         "name": "Call flow",
         "links": [],
         "linkType": "dynamic",
@@ -10447,19 +6499,19 @@
         "y": 100,
         "wires": [
             [
-                "92cf91937116658c"
+                "f226f40f1a8f6d50"
             ]
         ]
     },
     {
-        "id": "92cf91937116658c",
+        "id": "f226f40f1a8f6d50",
         "type": "link out",
-        "z": "ea282c9a1916db76",
-        "g": "1b9d9a2cb683bbba",
+        "z": "d60f98965bf0409c",
+        "g": "3864eee6ef12a6cf",
         "name": "go to End",
         "mode": "link",
         "links": [
-            "fcd9a95f1b45497c"
+            "9af5a7904623a82e"
         ],
         "x": 1970,
         "y": 100,
@@ -10467,10 +6519,10 @@
         "l": true
     },
     {
-        "id": "965ec6679352d78f",
+        "id": "01b253901b25116d",
         "type": "function",
-        "z": "ea282c9a1916db76",
-        "g": "1b9d9a2cb683bbba",
+        "z": "d60f98965bf0409c",
+        "g": "3864eee6ef12a6cf",
         "name": "Decided",
         "func": "const log = global.get(\"logger\");\n\nif(msg.charge.threshold_reached){\n    log(this,`Stop charging, Charge until ${msg.charge.goal} reached.`);\n} else {\n    log(this,`Continue charging.`);\n}\n\nreturn msg;",
         "outputs": 1,
@@ -10483,16 +6535,16 @@
         "y": 140,
         "wires": [
             [
-                "7b5b6de45bacd44f",
-                "b08d963419a0ef8f"
+                "8ca65cea7933f573",
+                "66e598d1b9d621b8"
             ]
         ]
     },
     {
-        "id": "b2ebdb1934e971af",
+        "id": "7732fdf8f7324a09",
         "type": "switch",
-        "z": "ea282c9a1916db76",
-        "g": "1b9d9a2cb683bbba",
+        "z": "d60f98965bf0409c",
+        "g": "3864eee6ef12a6cf",
         "name": "Charge until",
         "property": "charge.goal",
         "propertyType": "msg",
@@ -10528,27 +6580,27 @@
         "y": 180,
         "wires": [
             [
-                "a97682586d7a8650"
+                "2e79cc6f7e5fd376"
             ],
             [
-                "08e66a7a4d5aee4b"
+                "aeeffc28ca9116e3"
             ],
             [
-                "cbc44637fd9c21e8"
+                "03a2451155697047"
             ],
             [
-                "a46b37b48350cd6c"
+                "40c95cdba07a902b"
             ],
             [
-                "d3c73a6dca461f97"
+                "eb7b9310b7255bf1"
             ]
         ]
     },
     {
-        "id": "55a22f29f0144ebd",
+        "id": "b824e5983fb91749",
         "type": "api-current-state",
-        "z": "ea282c9a1916db76",
-        "g": "1b9d9a2cb683bbba",
+        "z": "d60f98965bf0409c",
+        "g": "3864eee6ef12a6cf",
         "name": "Goal",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -10591,15 +6643,15 @@
         "y": 180,
         "wires": [
             [
-                "b2ebdb1934e971af"
+                "7732fdf8f7324a09"
             ]
         ]
     },
     {
-        "id": "123af548fb46d3fc",
+        "id": "60818973c652a28b",
         "type": "function",
-        "z": "ea282c9a1916db76",
-        "g": "1b9d9a2cb683bbba",
+        "z": "d60f98965bf0409c",
+        "g": "3864eee6ef12a6cf",
         "name": "Init",
         "func": "msg.charge = {};\n\nreturn msg;",
         "outputs": 1,
@@ -10612,16 +6664,16 @@
         "y": 180,
         "wires": [
             [
-                "55a22f29f0144ebd",
-                "98acfc5db8fd84b2"
+                "b824e5983fb91749",
+                "6da488cbeae4a531"
             ]
         ]
     },
     {
-        "id": "e9407dbd0616c6ef",
+        "id": "3f6f7094b3c725a4",
         "type": "function",
-        "z": "ea282c9a1916db76",
-        "g": "0168fbfe69450274",
+        "z": "d60f98965bf0409c",
+        "g": "f5ea052a4d4f6b02",
         "name": "Min/max",
         "func": "\n// Lower bound\nlet output = msg.charge.threshold_energy || 0; // kWh\noutput = Math.max(output, 0);\n\n// Upper bound\noutput = Math.min(output, msg.batteries_max_energy);\n\nnode.status({fill:\"blue\",shape:\"dot\",text:`${output}`});\n\n// Output\nmsg.payload = Math.round(output * 100) / 100; // 2 decimals\nreturn msg;",
         "outputs": 1,
@@ -10634,15 +6686,15 @@
         "y": 360,
         "wires": [
             [
-                "d7137b33033d22a3"
+                "5ddb4e59c65e3f2c"
             ]
         ]
     },
     {
-        "id": "d7137b33033d22a3",
+        "id": "5ddb4e59c65e3f2c",
         "type": "api-call-service",
-        "z": "ea282c9a1916db76",
-        "g": "0168fbfe69450274",
+        "z": "d60f98965bf0409c",
+        "g": "f5ea052a4d4f6b02",
         "name": "Set desired energy reserve",
         "server": "176d29a.6f648d6",
         "version": 7,
@@ -10671,10 +6723,10 @@
         ]
     },
     {
-        "id": "1e5222f2eac079b6",
+        "id": "cc30a0b748b12089",
         "type": "rbe",
-        "z": "ea282c9a1916db76",
-        "g": "0168fbfe69450274",
+        "z": "d60f98965bf0409c",
+        "g": "f5ea052a4d4f6b02",
         "name": "Desired energy changed",
         "func": "rbei",
         "gap": "",
@@ -10687,15 +6739,15 @@
         "y": 360,
         "wires": [
             [
-                "e9407dbd0616c6ef"
+                "3f6f7094b3c725a4"
             ]
         ]
     },
     {
-        "id": "98acfc5db8fd84b2",
+        "id": "6da488cbeae4a531",
         "type": "debug",
-        "z": "ea282c9a1916db76",
-        "g": "1b9d9a2cb683bbba",
+        "z": "d60f98965bf0409c",
+        "g": "3864eee6ef12a6cf",
         "name": "debug 2",
         "active": true,
         "tosidebar": false,
@@ -10710,10 +6762,10 @@
         "wires": []
     },
     {
-        "id": "09ee061d1ab97a55",
+        "id": "896fbea1a27539b7",
         "type": "catch",
-        "z": "ea282c9a1916db76",
-        "g": "a05f0f93ec78e376",
+        "z": "d60f98965bf0409c",
+        "g": "f7b29c23bc50f575",
         "name": "",
         "scope": null,
         "uncaught": false,
@@ -10721,16 +6773,16 @@
         "y": 400,
         "wires": [
             [
-                "c6cfcb1bb71f9198"
+                "d6ce31820356b7f4"
             ]
         ],
         "l": false
     },
     {
-        "id": "c6cfcb1bb71f9198",
+        "id": "d6ce31820356b7f4",
         "type": "function",
-        "z": "ea282c9a1916db76",
-        "g": "a05f0f93ec78e376",
+        "z": "d60f98965bf0409c",
+        "g": "f7b29c23bc50f575",
         "name": "Unhandled Exception",
         "func": "const handle = global.get('unhandledException');\n\nhandle(this);\n\nreturn msg;",
         "outputs": 1,
@@ -10743,16 +6795,16 @@
         "y": 400,
         "wires": [
             [
-                "9d1d3ac35cc47fb3"
+                "24d2b649f1c319ef"
             ]
         ],
         "l": false
     },
     {
-        "id": "9d1d3ac35cc47fb3",
+        "id": "24d2b649f1c319ef",
         "type": "link out",
-        "z": "ea282c9a1916db76",
-        "g": "a05f0f93ec78e376",
+        "z": "d60f98965bf0409c",
+        "g": "f7b29c23bc50f575",
         "name": "link out 3",
         "mode": "return",
         "links": [],
@@ -10761,10 +6813,10 @@
         "wires": []
     },
     {
-        "id": "a46b37b48350cd6c",
+        "id": "40c95cdba07a902b",
         "type": "api-current-state",
-        "z": "ea282c9a1916db76",
-        "g": "1b9d9a2cb683bbba",
+        "z": "d60f98965bf0409c",
+        "g": "3864eee6ef12a6cf",
         "name": "Solar forecast",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -10807,15 +6859,15 @@
         "y": 220,
         "wires": [
             [
-                "695fbd98ef999747"
+                "a88c5148ece6f6c0"
             ]
         ]
     },
     {
-        "id": "695fbd98ef999747",
+        "id": "a88c5148ece6f6c0",
         "type": "api-current-state",
-        "z": "ea282c9a1916db76",
-        "g": "1b9d9a2cb683bbba",
+        "z": "d60f98965bf0409c",
+        "g": "3864eee6ef12a6cf",
         "name": "Solar threshold low",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -10852,16 +6904,16 @@
         "y": 220,
         "wires": [
             [
-                "20e2d0cbf1c5579a"
+                "ce2748d0e36567f9"
             ]
         ],
         "l": false
     },
     {
-        "id": "20e2d0cbf1c5579a",
+        "id": "ce2748d0e36567f9",
         "type": "function",
-        "z": "ea282c9a1916db76",
-        "g": "1b9d9a2cb683bbba",
+        "z": "d60f98965bf0409c",
+        "g": "3864eee6ef12a6cf",
         "name": "Check forecast",
         "func": "// 1. Get the custom logger from global context\nconst log = global.get(\"logger\");\nlog(this, `Charge using: ${msg.charge.goal}`);\n\n// 2. Energy levels and solar forecast from msg (default to 0 if property is missing)\nconst energy_available = Number(RED.util.getMessageProperty(msg, \"batteries_available_energy\")) || 0; // kWh\nconst energy_max = Number(RED.util.getMessageProperty(msg, \"batteries_max_energy\")) || 0; // kWh\nconst solar_threshold_low = Number(RED.util.getMessageProperty(msg, \"charge.solar_threshold_low\")) || 0; // kWh\nconst solar_forecast = Number(RED.util.getMessageProperty(msg,\"charge.solar_forecast_today\")) || 0; // kWh\n\n// 2.1 Desired charge level, considering the expected solar energy\nconst solar_surplus = Math.max(solar_forecast - solar_threshold_low, 0); // 0 or greater\nconst energy_desired = Math.max(energy_max - solar_surplus, 0); // 0 or greater\nif (solar_surplus == 0) {\n    log(this, `No solar surplus today. Forecast ${solar_forecast.toFixed(1)} kWh, with ${solar_threshold_low.toFixed(1)} kWh used by home.`);\n}\nif (energy_max == 0) log(this, `Batteries max energy unavailable!`, \"warn\");\n\n// 3. Logic: is charging required or is the charging threshold_reached\nif (energy_available >= energy_desired) {\n    // Done\n    msg.charge.threshold_reached = true;\n    // Explain\n    log(this, `[STOP] ${energy_available.toFixed(1)} battery + ${solar_surplus.toFixed(1)} solar = ok`, 'info');\n} else {\n    // Not ready\n    msg.charge.threshold_reached = false;\n    // Explain\n    log(this, `[CHARGE] From ${energy_available.toFixed(1)} -> ${energy_desired.toFixed(1)} kWh.`, 'info');\n}\n\n// 4. Update node status for visual feedback in the editor\nnode.status({\n    fill: msg.charge.threshold_reached ? \"red\" : \"green\",\n    shape: \"dot\",\n    text: `Threshold reached: ${msg.charge.threshold_reached} @ ${energy_desired.toFixed(1)} kWh`\n});\n\n// OUTPUT\nmsg.charge.threshold_energy = Number(energy_desired);\nmsg.payload = Number(energy_desired);\nreturn msg;",
         "outputs": 1,
@@ -10874,16 +6926,16 @@
         "y": 220,
         "wires": [
             [
-                "965ec6679352d78f",
-                "1e5222f2eac079b6"
+                "01b253901b25116d",
+                "cc30a0b748b12089"
             ]
         ]
     },
     {
-        "id": "4cc9caf9bcfade98",
+        "id": "a12c3943bfa94b58",
         "type": "api-call-service",
-        "z": "ea282c9a1916db76",
-        "g": "056683d4c0212e19",
+        "z": "d60f98965bf0409c",
+        "g": "aac3bf9516dbcc4e",
         "name": "Goal reached",
         "server": "176d29a.6f648d6",
         "version": 7,
@@ -10912,10 +6964,10 @@
         ]
     },
     {
-        "id": "7b5b6de45bacd44f",
+        "id": "8ca65cea7933f573",
         "type": "rbe",
-        "z": "ea282c9a1916db76",
-        "g": "056683d4c0212e19",
+        "z": "d60f98965bf0409c",
+        "g": "aac3bf9516dbcc4e",
         "name": "On Change",
         "func": "rbe",
         "gap": "",
@@ -10928,15 +6980,15 @@
         "y": 240,
         "wires": [
             [
-                "4890c6058de00446"
+                "c66d3097858658c1"
             ]
         ]
     },
     {
-        "id": "4890c6058de00446",
+        "id": "c66d3097858658c1",
         "type": "switch",
-        "z": "ea282c9a1916db76",
-        "g": "056683d4c0212e19",
+        "z": "d60f98965bf0409c",
+        "g": "aac3bf9516dbcc4e",
         "name": "Until reached",
         "property": "charge.threshold_reached",
         "propertyType": "msg",
@@ -10955,18 +7007,18 @@
         "y": 240,
         "wires": [
             [
-                "4cc9caf9bcfade98"
+                "a12c3943bfa94b58"
             ],
             [
-                "3312e425d31523f4"
+                "a0755655090bf55f"
             ]
         ]
     },
     {
-        "id": "3312e425d31523f4",
+        "id": "a0755655090bf55f",
         "type": "api-call-service",
-        "z": "ea282c9a1916db76",
-        "g": "056683d4c0212e19",
+        "z": "d60f98965bf0409c",
+        "g": "aac3bf9516dbcc4e",
         "name": "Goal unmet",
         "server": "176d29a.6f648d6",
         "version": 7,
@@ -10995,25 +7047,25 @@
         ]
     },
     {
-        "id": "10b840d73039794e",
+        "id": "02c9f5debe469ff7",
         "type": "link in",
-        "z": "99f6e455efa54b3a",
-        "g": "d3c9838fd79f66ff",
+        "z": "c11340415b97b938",
+        "g": "1e4d2d34b639b7f8",
         "name": "Dynamic",
         "links": [],
         "x": 100,
         "y": 160,
         "wires": [
             [
-                "d90bac11be9193dd"
+                "11b8c0e6011b9efb"
             ]
         ],
         "l": true
     },
     {
-        "id": "f6e3d529b7b943dd",
+        "id": "5a9828b411dd6db3",
         "type": "comment",
-        "z": "99f6e455efa54b3a",
+        "z": "c11340415b97b938",
         "name": "Home Battery Strategy",
         "info": "The `Home Battery Start` flow will call this strategy flow\nby matching the strategy name with the Link In name.\n\nConfigure the Link In node in the Start group.\n\nDon't modify other parts of the Start and End groups.\nThey handle the calling and returning for you.",
         "x": 120,
@@ -11021,10 +7073,10 @@
         "wires": []
     },
     {
-        "id": "de82e260dd892bd8",
+        "id": "2eab1c5e3e74ddea",
         "type": "comment",
-        "z": "99f6e455efa54b3a",
-        "g": "d3c9838fd79f66ff",
+        "z": "c11340415b97b938",
+        "g": "1e4d2d34b639b7f8",
         "name": "Start (readme)",
         "info": "# Setting up your battery strategy flow\n\n## Setup\nName the `Link In node` in this start group exactly after the <select> option configured in your\nselect_input.house_battery_strategy\n\nconfigure select options in:\ninput_select_house_battery_control.yaml\n\n### example\n`house_battery_strategy:\n  name: House Battery Strategy\n  options:\n    - AcmE example`\n\nThe above creates a select option, allowing user to select 'AcmE example'\n\nWhen selected, battery control will search for a flow containing a Link In node\ncalled 'AcmE example' (case sensitive).",
         "x": 110,
@@ -11032,10 +7084,10 @@
         "wires": []
     },
     {
-        "id": "b4698212756bbf09",
+        "id": "576355e6681c94a4",
         "type": "link out",
-        "z": "99f6e455efa54b3a",
-        "g": "82fa2a7ed35302d9",
+        "z": "c11340415b97b938",
+        "g": "608fa319cec8ec48",
         "name": "Return",
         "mode": "return",
         "links": [],
@@ -11044,10 +7096,10 @@
         "wires": []
     },
     {
-        "id": "e7b989fd220fb54f",
+        "id": "dc992ac885050b63",
         "type": "comment",
-        "z": "99f6e455efa54b3a",
-        "g": "82fa2a7ed35302d9",
+        "z": "c11340415b97b938",
+        "g": "608fa319cec8ec48",
         "name": "End (readme)",
         "info": "Should return a solution_array of battery objects\n\n## battery object format\n`{{id: string|number, mode: string, power: number}} battery solution`\n- id is an arbitrary battery ID\n- mode is \"stop\", \"charge\", \"discharge\" for Marstek\n- power in Watts\n\n### example array\nreturn this type of solution_array via msg.solutions\n` \nlet solution_array = [];\nsolution_array.push({id:\"M1\", mode: \"charge\", power: 100}); // per battery\nreturn {solutions: solution_array};\n` ",
         "x": 1030,
@@ -11055,10 +7107,10 @@
         "wires": []
     },
     {
-        "id": "9a68105b2f6b975c",
+        "id": "34fd784e608d9d54",
         "type": "api-render-template",
-        "z": "99f6e455efa54b3a",
-        "g": "101917fb25d567d6",
+        "z": "c11340415b97b938",
+        "g": "b974ba39dc7d0bca",
         "name": "Cheapest",
         "server": "176d29a.6f648d6",
         "version": 0,
@@ -11071,15 +7123,15 @@
         "y": 660,
         "wires": [
             [
-                "a7d2619afbf92a40"
+                "8f1db7f696ab7441"
             ]
         ]
     },
     {
-        "id": "eee4e7f3304c26ed",
+        "id": "64ac7813f1f8a906",
         "type": "api-render-template",
-        "z": "99f6e455efa54b3a",
-        "g": "101917fb25d567d6",
+        "z": "c11340415b97b938",
+        "g": "b974ba39dc7d0bca",
         "name": "Expensive",
         "server": "176d29a.6f648d6",
         "version": 0,
@@ -11092,15 +7144,15 @@
         "y": 720,
         "wires": [
             [
-                "054edde1a66b20e2"
+                "8f918ce3ce0a6c8a"
             ]
         ]
     },
     {
-        "id": "3b03078088842f6c",
+        "id": "c440e478825fb651",
         "type": "debug",
-        "z": "99f6e455efa54b3a",
-        "g": "b4d8861efefe4972",
+        "z": "c11340415b97b938",
+        "g": "b2852c433afeb8cc",
         "name": "Complete message",
         "active": true,
         "tosidebar": true,
@@ -11115,10 +7167,10 @@
         "wires": []
     },
     {
-        "id": "a7d2619afbf92a40",
+        "id": "8f1db7f696ab7441",
         "type": "json",
-        "z": "99f6e455efa54b3a",
-        "g": "101917fb25d567d6",
+        "z": "c11340415b97b938",
+        "g": "b974ba39dc7d0bca",
         "name": "",
         "property": "dynamic.data_cheapest",
         "action": "obj",
@@ -11127,16 +7179,16 @@
         "y": 660,
         "wires": [
             [
-                "653113bbb5c213d4"
+                "7957ba42cec8c33a"
             ]
         ],
         "l": false
     },
     {
-        "id": "054edde1a66b20e2",
+        "id": "8f918ce3ce0a6c8a",
         "type": "json",
-        "z": "99f6e455efa54b3a",
-        "g": "101917fb25d567d6",
+        "z": "c11340415b97b938",
+        "g": "b974ba39dc7d0bca",
         "name": "",
         "property": "dynamic.data_expensive",
         "action": "obj",
@@ -11145,16 +7197,16 @@
         "y": 720,
         "wires": [
             [
-                "56dd9fa3c398c149"
+                "1b934ae07c52fa8e"
             ]
         ],
         "l": false
     },
     {
-        "id": "2178a721499737da",
+        "id": "7c23c7e9d9c9c21d",
         "type": "function",
-        "z": "99f6e455efa54b3a",
-        "g": "b4d8861efefe4972",
+        "z": "c11340415b97b938",
+        "g": "b2852c433afeb8cc",
         "name": "Determine dynamic strategy",
         "func": "// logger, usage: log(this, \"\");\nconst log = global.get('logger');\n\n// 1.   Input\n// Conversion\nconst CONVERSION_RATE = parseFloat(RED.util.getMessageProperty(msg, \"dynamic.value_conversion\")) || 1;\n\n// extract start/end date objects\nconst start_cheapest = new Date(RED.util.getMessageProperty(msg,\"dynamic.data_cheapest.start\"));\nconst start_expensive = new Date(RED.util.getMessageProperty(msg,\"dynamic.data_expensive.start\"));\nconst end_cheapest = new Date(RED.util.getMessageProperty(msg, \"dynamic.data_cheapest.end\"));\nconst end_expensive = new Date(RED.util.getMessageProperty(msg, \"dynamic.data_expensive.end\"));\nlet isCheapestNext = true;\n// stored price cheapest period\nlet lastCheapestPrice = context.last_cheapest_price || 0; // unit: cents/kWh\nconst nextCheapestPrice = parseInt(RED.util.getMessageProperty(msg, \"dynamic.data_cheapest.average\") / CONVERSION_RATE * 100); // unit: cents/kWh \n// average price expensive period\nconst lastExpensivePrice = parseInt(RED.util.getMessageProperty(msg, \"dynamic.data_expensive.average\") / CONVERSION_RATE * 100); // unit: cents/kWh\n// threshold rate for cheapest period\nconst cheapestThresholdCents = parseInt(RED.util.getMessageProperty(msg, \"dynamic.threshold_cheapest_cents\")) || 0; // unit: cents\n// threshold delta for expensive period\nconst deltaThresholdCents = parseInt(RED.util.getMessageProperty(msg, \"dynamic.min_delta_cents\")) || 0; // unit: cents\n\n// 1.1  Enums\nconst STRATEGY = {\n    CHEAPEST: RED.util.getMessageProperty(msg,\"dynamic.strategy_cheapest\") || \"Charge\", \n    NEUTRAL: RED.util.getMessageProperty(msg,\"dynamic.strategy_default\") || \"Charge PV\",\n    EXPENSIVE: RED.util.getMessageProperty(msg,\"dynamic.strategy_expensive\") || \"Self-consumption\"\n}\n\n// 1.2  Defaults   \nmsg.dynamic.avg_cheapest_tariff = 0;\nmsg.dynamic.avg_expensive_tariff = 0;\nmsg.dynamic.avg_delta = 0;\n\n// 2.   Tariffs\n// Check if the Date objects are valid. If 'Invalid Date', stop and warn the user.\nif (isNaN(start_cheapest.getTime()) || isNaN(start_expensive.getTime())) {\n    // warn user\n    log(this, `One or both dates are invalid. Cheap = ${start_cheapest}, Expensive = ${start_expensive}`,\"warn\");\n    node.status({fill:\"red\",shape:\"ring\",text:`One or both dates are invalid: ${start_cheapest}, ${start_expensive}`});\n    // fallback strategy\n    flow.set(\"dynamic_strategy\", STRATEGY.NEUTRAL);\n    // proceed to UI\n    return msg;\n}\n\n// Check if cheapest lies before expensive\nif (start_cheapest < start_expensive) {\n    log(this, `Cheapest moment lies before expensive moment. Cheapest moment: ${start_cheapest}, Expensive = ${start_expensive}`);\n    // store the cheapest price to compare it with future expensive rates, to determine if it's economical to discharge.\n    context.last_cheapest_price = nextCheapestPrice; // store for next iteration\n    lastCheapestPrice = nextCheapestPrice; // used for this iteration\n    log(this, `Cheapest price set to ${lastCheapestPrice} cents`);\n}\n\nif (lastCheapestPrice == 0) {\n    log(this, `I can't recall the tariff used for charging. Cheapest price set to '${lastCheapestPrice}' cents`);\n}\n\n// delta > N cents ? -> charging is economical\nconst delta = (lastExpensivePrice - lastCheapestPrice); // unit: cents\n\n// UI values\nmsg.dynamic.avg_cheapest_tariff = lastCheapestPrice;\nmsg.dynamic.avg_expensive_tariff = lastExpensivePrice;\nmsg.dynamic.avg_delta = delta;\n\n// 3.   Strategy selection logic\n// for string time\nfunction isTimeInPeriod(startStr, endStr) {\n    const now = new Date();\n    const start = new Date(startStr);\n    const end = new Date(endStr);\n    return (now >= start && now < end);\n}\n// 3.1  is_now - which period have we entered?\nconst now = new Date();\n/** @type {boolean} */\nconst cheapestIsNow = now >= start_cheapest && now <= end_cheapest;\n// const cheapestIsNow = RED.util.getMessageProperty(msg,\"dynamic.data_cheapest.is_now\");\n/** @type {boolean} */\nconst expensiveIsNow = now >= start_expensive && now <= end_expensive;\n// const expensiveIsNow = RED.util.getMessageProperty(msg, \"dynamic.data_expensive.is_now\");\n\n// 3.2  Set strategy\n// Default strategy\nmsg.dynamic.strategy = STRATEGY.NEUTRAL;\n\n// Cheapest period?\nif (cheapestIsNow && lastCheapestPrice <= cheapestThresholdCents) {\n    msg.dynamic.strategy = STRATEGY.CHEAPEST;\n    // Explain\n    log(this, `**Cheapest period is NOW**, price limit: ${lastCheapestPrice}/${cheapestThresholdCents} cents OK`);\n} else if(cheapestIsNow) {\n    // Explain why skipped\n    log(this, `**Cheapest period SKIPPED**, the cheapest period is too expensive today. Price limit: ${lastCheapestPrice}/${cheapestThresholdCents} cents.`);\n}\n\n// Expensive period?\nif (expensiveIsNow && delta >= deltaThresholdCents) {\n    msg.dynamic.strategy = STRATEGY.EXPENSIVE;\n    // Explain\n    log(this, `**Expensive period is NOW**, price delta: ${delta}>=${deltaThresholdCents} cents OK`);\n} else if(expensiveIsNow) {\n    // Explain why skipped\n    log(this, `**Expensive period SKIPPED**, price delta too small: ${lastExpensivePrice}-${lastCheapestPrice}=${delta} cents <= ${deltaThresholdCents} cents`); \n}\n\n// 3.3  Store the strategy in flow-context. The 'Execution' area will read from the flow-context.\nflow.set(\"dynamic_strategy\",msg.dynamic.strategy);\n\n// 4.   User feedback\n// Node status\nnode.status({ fill: \"blue\", shape: \"dot\", text: `${msg.dynamic.strategy}; ${cheapestIsNow} + ${expensiveIsNow} @ ${delta} cents` });\n// Explain\nlog(this, `Strategy set to **${msg.dynamic.strategy}**`);\n\n// Proceed to UI update\nreturn msg;",
         "outputs": 1,
@@ -11167,23 +7219,23 @@
         "y": 1140,
         "wires": [
             [
-                "3b03078088842f6c",
-                "7541537e74f52f0f",
-                "f984611e3ccc84c9",
-                "f91c2013220ea334",
-                "eb3ace62bb381ab5",
-                "a51a5cd98b789771",
-                "d94fa194cae868ad",
-                "687936a77e0f906d",
-                "6b2377c655bd05fc"
+                "c440e478825fb651",
+                "21af2478e7e13247",
+                "94a6aee346dc3833",
+                "d49038e8a4407299",
+                "bb9c63a891fa0e86",
+                "1d6b8b8a07984e20",
+                "143c21e7820f372f",
+                "9684b85dd4952a26",
+                "a0270d19a585a526"
             ]
         ]
     },
     {
-        "id": "d1f365c57678f171",
+        "id": "e09e9cb63348d8ed",
         "type": "change",
-        "z": "99f6e455efa54b3a",
-        "g": "72b9126748df875e",
+        "z": "c11340415b97b938",
+        "g": "d145546c4cfb1e34",
         "name": "Set strategy",
         "rules": [
             {
@@ -11203,15 +7255,15 @@
         "y": 200,
         "wires": [
             [
-                "26b26089165ee47f"
+                "0942c21d9a7aaefa"
             ]
         ]
     },
     {
-        "id": "72dfc4f99ef6204b",
+        "id": "72965df35ce116d9",
         "type": "link call",
-        "z": "99f6e455efa54b3a",
-        "g": "72b9126748df875e",
+        "z": "c11340415b97b938",
+        "g": "d145546c4cfb1e34",
         "name": "Sub-strategy",
         "links": [],
         "linkType": "dynamic",
@@ -11220,15 +7272,15 @@
         "y": 180,
         "wires": [
             [
-                "b4698212756bbf09"
+                "576355e6681c94a4"
             ]
         ]
     },
     {
-        "id": "7541537e74f52f0f",
+        "id": "21af2478e7e13247",
         "type": "api-call-service",
-        "z": "99f6e455efa54b3a",
-        "g": "b4d8861efefe4972",
+        "z": "c11340415b97b938",
+        "g": "b2852c433afeb8cc",
         "name": "Cheapest Start",
         "server": "176d29a.6f648d6",
         "version": 7,
@@ -11257,10 +7309,10 @@
         ]
     },
     {
-        "id": "f984611e3ccc84c9",
+        "id": "94a6aee346dc3833",
         "type": "api-call-service",
-        "z": "99f6e455efa54b3a",
-        "g": "b4d8861efefe4972",
+        "z": "c11340415b97b938",
+        "g": "b2852c433afeb8cc",
         "name": "Cheapest End",
         "server": "176d29a.6f648d6",
         "version": 7,
@@ -11289,10 +7341,10 @@
         ]
     },
     {
-        "id": "f91c2013220ea334",
+        "id": "d49038e8a4407299",
         "type": "api-call-service",
-        "z": "99f6e455efa54b3a",
-        "g": "b4d8861efefe4972",
+        "z": "c11340415b97b938",
+        "g": "b2852c433afeb8cc",
         "name": "Expensive Start",
         "server": "176d29a.6f648d6",
         "version": 7,
@@ -11321,10 +7373,10 @@
         ]
     },
     {
-        "id": "eb3ace62bb381ab5",
+        "id": "bb9c63a891fa0e86",
         "type": "api-call-service",
-        "z": "99f6e455efa54b3a",
-        "g": "b4d8861efefe4972",
+        "z": "c11340415b97b938",
+        "g": "b2852c433afeb8cc",
         "name": "Expensive End",
         "server": "176d29a.6f648d6",
         "version": 7,
@@ -11353,10 +7405,10 @@
         ]
     },
     {
-        "id": "4453c2db4c12e57c",
+        "id": "963292f96d950b74",
         "type": "inject",
-        "z": "99f6e455efa54b3a",
-        "g": "1c58bd73aef4538b",
+        "z": "c11340415b97b938",
+        "g": "8c1deab0e5e6f11a",
         "name": "Every 60 min",
         "props": [
             {
@@ -11378,15 +7430,15 @@
         "y": 420,
         "wires": [
             [
-                "8ecb9358ad2a9548"
+                "e5404cfdb2ab9409"
             ]
         ]
     },
     {
-        "id": "3688acf38b3e7b48",
+        "id": "9fa38679952970f8",
         "type": "switch",
-        "z": "99f6e455efa54b3a",
-        "g": "72b9126748df875e",
+        "z": "c11340415b97b938",
+        "g": "d145546c4cfb1e34",
         "name": "Has strategy",
         "property": "dynamic_strategy",
         "propertyType": "flow",
@@ -11405,18 +7457,18 @@
         "y": 180,
         "wires": [
             [
-                "e50e769f731f1a5c"
+                "fa4df9d2aacebeab"
             ],
             [
-                "d1f365c57678f171"
+                "e09e9cb63348d8ed"
             ]
         ]
     },
     {
-        "id": "e50e769f731f1a5c",
+        "id": "fa4df9d2aacebeab",
         "type": "change",
-        "z": "99f6e455efa54b3a",
-        "g": "72b9126748df875e",
+        "z": "c11340415b97b938",
+        "g": "d145546c4cfb1e34",
         "name": "Set Full stop",
         "rules": [
             {
@@ -11436,15 +7488,15 @@
         "y": 160,
         "wires": [
             [
-                "26b26089165ee47f"
+                "0942c21d9a7aaefa"
             ]
         ]
     },
     {
-        "id": "b20a8cd75d1686bd",
+        "id": "9091501a4d56f41c",
         "type": "inject",
-        "z": "99f6e455efa54b3a",
-        "g": "8738b26b32fee4e0",
+        "z": "c11340415b97b938",
+        "g": "2d3ed289b08737e5",
         "name": "Test",
         "props": [
             {
@@ -11466,15 +7518,15 @@
         "y": 1520,
         "wires": [
             [
-                "8997d0a8d7413f77"
+                "482804fa0836772f"
             ]
         ]
     },
     {
-        "id": "8997d0a8d7413f77",
+        "id": "482804fa0836772f",
         "type": "api-render-template",
-        "z": "99f6e455efa54b3a",
-        "g": "8738b26b32fee4e0",
+        "z": "c11340415b97b938",
+        "g": "2d3ed289b08737e5",
         "name": "Cheapest",
         "server": "176d29a.6f648d6",
         "version": 0,
@@ -11487,15 +7539,15 @@
         "y": 1520,
         "wires": [
             [
-                "1e42511310237759"
+                "6bf27a045a91b6e9"
             ]
         ]
     },
     {
-        "id": "1e42511310237759",
+        "id": "6bf27a045a91b6e9",
         "type": "json",
-        "z": "99f6e455efa54b3a",
-        "g": "8738b26b32fee4e0",
+        "z": "c11340415b97b938",
+        "g": "2d3ed289b08737e5",
         "name": "",
         "property": "cheapest",
         "action": "obj",
@@ -11504,16 +7556,16 @@
         "y": 1520,
         "wires": [
             [
-                "48c31efefebe1bd4"
+                "4bfde5abb555b87c"
             ]
         ],
         "l": false
     },
     {
-        "id": "48c31efefebe1bd4",
+        "id": "4bfde5abb555b87c",
         "type": "api-render-template",
-        "z": "99f6e455efa54b3a",
-        "g": "8738b26b32fee4e0",
+        "z": "c11340415b97b938",
+        "g": "2d3ed289b08737e5",
         "name": "Expensive",
         "server": "176d29a.6f648d6",
         "version": 0,
@@ -11526,15 +7578,15 @@
         "y": 1520,
         "wires": [
             [
-                "f3857f90af5bca4f"
+                "a5d382a0064f1008"
             ]
         ]
     },
     {
-        "id": "f3857f90af5bca4f",
+        "id": "a5d382a0064f1008",
         "type": "json",
-        "z": "99f6e455efa54b3a",
-        "g": "8738b26b32fee4e0",
+        "z": "c11340415b97b938",
+        "g": "2d3ed289b08737e5",
         "name": "",
         "property": "expensive",
         "action": "obj",
@@ -11543,18 +7595,18 @@
         "y": 1520,
         "wires": [
             [
-                "bc15733f1195e478",
-                "80d5e168f64fb057",
-                "9ef13a670cc957eb"
+                "cecb18338a342a0e",
+                "aa39b322023b6826",
+                "b793788cb3a23b5c"
             ]
         ],
         "l": false
     },
     {
-        "id": "bc15733f1195e478",
+        "id": "cecb18338a342a0e",
         "type": "debug",
-        "z": "99f6e455efa54b3a",
-        "g": "8738b26b32fee4e0",
+        "z": "c11340415b97b938",
+        "g": "2d3ed289b08737e5",
         "name": "Cheap",
         "active": true,
         "tosidebar": false,
@@ -11569,10 +7621,10 @@
         "wires": []
     },
     {
-        "id": "80d5e168f64fb057",
+        "id": "aa39b322023b6826",
         "type": "debug",
-        "z": "99f6e455efa54b3a",
-        "g": "8738b26b32fee4e0",
+        "z": "c11340415b97b938",
+        "g": "2d3ed289b08737e5",
         "name": "Expensive",
         "active": true,
         "tosidebar": false,
@@ -11587,10 +7639,10 @@
         "wires": []
     },
     {
-        "id": "bc2762fc445314c0",
+        "id": "70ab5c095d9a04d6",
         "type": "api-render-template",
-        "z": "99f6e455efa54b3a",
-        "g": "f4d47a8395e2352b",
+        "z": "c11340415b97b938",
+        "g": "066f5b1fcc1b752c",
         "name": "All Zonneplan",
         "server": "176d29a.6f648d6",
         "version": 0,
@@ -11603,15 +7655,15 @@
         "y": 1700,
         "wires": [
             [
-                "749fc82a266798a1"
+                "40ce2759a2b947e0"
             ]
         ]
     },
     {
-        "id": "e6cce059e172bc4f",
+        "id": "a8e46e32a85d4101",
         "type": "inject",
-        "z": "99f6e455efa54b3a",
-        "g": "f4d47a8395e2352b",
+        "z": "c11340415b97b938",
+        "g": "066f5b1fcc1b752c",
         "name": "Fetch",
         "props": [
             {
@@ -11633,15 +7685,15 @@
         "y": 1700,
         "wires": [
             [
-                "bc2762fc445314c0"
+                "70ab5c095d9a04d6"
             ]
         ]
     },
     {
-        "id": "749fc82a266798a1",
+        "id": "40ce2759a2b947e0",
         "type": "json",
-        "z": "99f6e455efa54b3a",
-        "g": "f4d47a8395e2352b",
+        "z": "c11340415b97b938",
+        "g": "066f5b1fcc1b752c",
         "name": "",
         "property": "all_data",
         "action": "obj",
@@ -11650,17 +7702,17 @@
         "y": 1700,
         "wires": [
             [
-                "ca1888369786df2c",
-                "3c738f8cc897b9c2"
+                "8f3c1e64dd9cd8c1",
+                "f8fad8da4ec02e6d"
             ]
         ],
         "l": false
     },
     {
-        "id": "8ecb9358ad2a9548",
+        "id": "e5404cfdb2ab9409",
         "type": "delay",
-        "z": "99f6e455efa54b3a",
-        "g": "1c58bd73aef4538b",
+        "z": "c11340415b97b938",
+        "g": "8c1deab0e5e6f11a",
         "name": "",
         "pauseType": "delay",
         "timeout": "1",
@@ -11678,15 +7730,15 @@
         "y": 420,
         "wires": [
             [
-                "65cb86cc40d09a4f"
+                "88e001bdc138d861"
             ]
         ]
     },
     {
-        "id": "a10482f4b176de1c",
+        "id": "7df5f321724f926e",
         "type": "api-current-state",
-        "z": "99f6e455efa54b3a",
-        "g": "1c58bd73aef4538b",
+        "z": "c11340415b97b938",
+        "g": "8c1deab0e5e6f11a",
         "name": "Source",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -11729,15 +7781,15 @@
         "y": 380,
         "wires": [
             [
-                "cce5bc49088b006a"
+                "7b84c64641b09f1a"
             ]
         ]
     },
     {
-        "id": "c70c81db78db986d",
+        "id": "f69d6b41f3833758",
         "type": "function",
-        "z": "99f6e455efa54b3a",
-        "g": "101917fb25d567d6",
+        "z": "c11340415b97b938",
+        "g": "b974ba39dc7d0bca",
         "name": "Data source settings",
         "func": "// logger, usage: log(this, \"\");\nconst log = global.get('logger');\n\n/*    From cheapes-energy-hours macro\n      See: https://github.com/TheFes/cheapest-energy-hours/blob/main/documentation/1-source_data.md#data-provider-settings\n\n      - None (default selection)\n      - Zonneplan\n      - Amber Electric\n      - EasyEnergy, EnergyZero (core)\n      - ENTSO-E\n      - Frank Energie\n      - GE-Spot\n      - Tibber, Nordpool (core)\n      - Tibber (custom)\n      - Nordpool (custom)\n      - PVPC (Spain)\n      - Octopus Energy\n      - Omie\n*/\n\nswitch (msg.dynamic.data_source) {\n      case \"None\":\n            // Handle the 'None' case (e.g., no supplier selected or data is unavailable)\n            log(this,\"No data source selected.\");\n            // Add config here...\n            break;\n\n      case \"Zonneplan\":\n            // Code for Zonneplan (a Dutch energy supplier)\n            log(this,\"Processing Zonneplan data.\");\n            // Add config here...\n            msg.dynamic.sensor='sensor.zonneplan_current_electricity_tariff'; // when using: https://github.com/fsaris/home-assistant-zonneplan-one\n            msg.dynamic.source_settings='zonneplan'\n            // msg.dynamic.attr_all='forecast';\n            // msg.dynamic.value_key='electricity_price';\n            msg.dynamic.value_conversion = 10000000; // whole currency / kWh\n            break;\n\n      case \"Amber Electric\":\n            // Code for Amber Electric (Australian energy retailer)\n            log(this,\"Processing Amber Electric data.\");\n            // Add config here...\n            msg.dynamic.attr_all='forecasts'; \n            msg.dynamic.time_key='start_time'; \n            msg.dynamic.value_key='per_kwh';\n            break;\n\n      case \"EasyEnergy, EnergyZero (core)\":\n            // Code for EasyEnergy and EnergyZero (core/default implementation)\n            log(this,\"Processing EasyEnergy/EnergyZero core data.\");\n            // Add config here...\n            break;\n\n      case \"ENTSO-E\":\n            // Code for ENTSO-E (European Network of Transmission System Operators for Electricity)\n            log(this,\"Processing ENTSO-E data.\");\n            // Add config here...\n            msg.dynamic.attr_today='prices_today'; \n            msg.dynamic.attr_tomorrow='prices_tomorrow'; \n            msg.dynamic.time_key='time';\n            msg.dynamic.value_key='price';\n            break;\n\n      case \"Frank Energie\":\n            // Code for Frank Energie (Dutch energy supplier)\n            log(this,\"Processing Frank Energie data.\");\n            // Add config here...\n            msg.dynamic.sensor = 'sensor.frank_energie_prijzen_gemiddelde_elektriciteitsprijs_alle_uren_all_in'; // when using: https://github.com/HiDiHo01/home-assistant-frank_energie\n            msg.dynamic.attr_all = 'prices'; \n            msg.dynamic.time_key = 'from'; \n            msg.dynamic.value_key = 'price';\n            break;\n\n      case \"GE-Spot\":\n            // Code for GE-Spot (Global Electric Spot price)\n            log(this,\"Processing GE-Spot data.\");\n            // Add config here...\n            msg.dynamic.attr_today = 'today_hourly_prices'; // using the hourly version. today_interval_prices is per 15 mins\n            msg.dynamic.attr_tomorrow = 'tomorrow_hourly_prices'; // using the hourly version\n            msg.dynamic.time_key = 'time'; \n            msg.dynamic.value_key = 'value';\n            break;\n\n      case \"Nordpool (core)\":\n            // Code for Nordpool (core/default implementation)\n            log(this, \"Processing Nordpool core data.\");\n            // Add config here...\n            msg.dynamic.sensor = 'sensor.nordpool_ceh_prices';\n            msg.dynamic.attr_today = 'today';\n            msg.dynamic.attr_tomorrow = 'tomorrow';\n            msg.dynamic.time_key = 'start';\n            msg.dynamic.value_key = 'value';\n            msg.dynamic.datetime_in_data = true; // datetime is in the data\n            break;\n\n      case \"Tibber (core)\":\n            // Code for Tibber (core/default implementation)\n            log(this,\"Processing Tibber core data.\");\n            // Add config here...\n            msg.dynamic.sensor = 'sensor.tibber_ceh_prices';\n            msg.dynamic.attr_today = 'today';\n            msg.dynamic.attr_tomorrow = 'tomorrow';\n            msg.dynamic.time_key = 'start';\n            msg.dynamic.value_key = 'value';\n            msg.dynamic.datetime_in_data = true; // datetime is in the data\n            break;\n\n      case \"Tibber (custom)\":\n            // Code for a custom Tibber setup/configuration\n            log(this,\"Processing Tibber custom data.\");\n            // Add config here...\n            msg.dynamic.attr_today = 'today';\n            msg.dynamic.attr_tomorrow = 'tomorrow';\n            msg.dynamic.datetime_in_data = false;\n            break;\n\n      case \"Nordpool (custom)\":\n            // Code for a custom Nordpool setup/configuration\n            log(this,\"Processing Nordpool custom data.\");\n            // Add config here...\n            break;\n\n      case \"PVPC (Spain)\":\n            // Code for PVPC (Voluntary Price for Small Consumers in Spain)\n            log(this,\"Processing Spanish PVPC data.\");\n            // Add config here...\n            break;\n\n      case \"Octopus Energy\":\n            // Code for Octopus Energy (UK/international energy supplier)\n            log(this,\"Processing Octopus Energy data.\");\n            // Add config here...\n            msg.dynamic.attr_all = 'rates'; \n            msg.dynamic.value_key = 'value_incl_vat';\n            break;\n\n      case \"Omie\":\n            // Code for Omie (Iberian Energy Market Operator)\n            log(this,\"Processing Omie data.\");\n            // Add config here...\n            break;\n\n      default:\n            // Code to execute if the supplier does not match any of the above cases\n            node.warn(`Unknown supplier: ${msg.dynamic.data_source}. Using default logic.`);\n            log(this,`Unknown supplier: ${msg.dynamic.data_source}. Using default logic.`);\n            // Add default error handling...\n}\n\nlog(this, \"Performing API calls...\");\n\nreturn msg;",
         "outputs": 1,
@@ -11750,15 +7802,15 @@
         "y": 600,
         "wires": [
             [
-                "c4f8b98f5b87d363"
+                "9363c4bd159453fc"
             ]
         ]
     },
     {
-        "id": "6c27d2c4744e1e45",
+        "id": "877fbda0b5917a30",
         "type": "api-current-state",
-        "z": "99f6e455efa54b3a",
-        "g": "1c58bd73aef4538b",
+        "z": "c11340415b97b938",
+        "g": "8c1deab0e5e6f11a",
         "name": "Cheapest N hrs",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -11801,15 +7853,15 @@
         "y": 380,
         "wires": [
             [
-                "0af742a1171ddcde"
+                "cdd87a392dbb639a"
             ]
         ]
     },
     {
-        "id": "0af742a1171ddcde",
+        "id": "cdd87a392dbb639a",
         "type": "api-current-state",
-        "z": "99f6e455efa54b3a",
-        "g": "1c58bd73aef4538b",
+        "z": "c11340415b97b938",
+        "g": "8c1deab0e5e6f11a",
         "name": "Expensive N hrs",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -11852,15 +7904,15 @@
         "y": 420,
         "wires": [
             [
-                "2436febcc68a269d"
+                "3cc700a138b05de6"
             ]
         ]
     },
     {
-        "id": "919bb0e478c3cc38",
+        "id": "707996bcaabe85a5",
         "type": "inject",
-        "z": "99f6e455efa54b3a",
-        "g": "1c58bd73aef4538b",
+        "z": "c11340415b97b938",
+        "g": "8c1deab0e5e6f11a",
         "name": "Check period",
         "props": [
             {
@@ -11882,15 +7934,15 @@
         "y": 380,
         "wires": [
             [
-                "daaff12efb064bd6"
+                "0eacfd9ccf95222c"
             ]
         ]
     },
     {
-        "id": "daaff12efb064bd6",
+        "id": "0eacfd9ccf95222c",
         "type": "function",
-        "z": "99f6e455efa54b3a",
-        "g": "1c58bd73aef4538b",
+        "z": "c11340415b97b938",
+        "g": "8c1deab0e5e6f11a",
         "name": "Init",
         "func": "msg.dynamic = {};\nmsg.log = [];\nreturn msg;",
         "outputs": 1,
@@ -11903,15 +7955,15 @@
         "y": 380,
         "wires": [
             [
-                "a10482f4b176de1c"
+                "7df5f321724f926e"
             ]
         ]
     },
     {
-        "id": "c4f8b98f5b87d363",
+        "id": "9363c4bd159453fc",
         "type": "function",
-        "z": "99f6e455efa54b3a",
-        "g": "101917fb25d567d6",
+        "z": "c11340415b97b938",
+        "g": "b974ba39dc7d0bca",
         "name": "Generate templates",
         "func": "// final template initialization\nmsg.dynamic.template_cheapest = \"\";\nmsg.dynamic.template_expensive = \"\";\n\n// temporary template parts\nlet template_start = \"\";\nlet template_common = [];\nlet template_cheapest = [];\nlet template_expensive = [];\nlet template_all = [];\nlet template_end = \"\";\n\n// 1. IMPROVEMENT: Use radix 10 and Logical OR (||) for cleaner default handling\nconst cheapest_hrs = parseInt(RED.util.getMessageProperty(msg,\"dynamic.cheapest_hrs\"), 10) || 1;\nconst expensive_hrs = parseInt(RED.util.getMessageProperty(msg,\"dynamic.expensive_hrs\"), 10) || 1;\n\n// load the macro\ntemplate_start = `{% from 'cheapest_energy_hours.jinja' import cheapest_energy_hours %}\n{{ cheapest_energy_hours(\n`;\ntemplate_end = `) | to_json }}`;\n\n// collect arguments | strings\nconst stringKeys = [\n    'sensor',\n    'attr_all',\n    'value_key',\n    'attr_today',\n    'attr_tomorrow',\n    'time_key',\n    'source_settings'\n];\n\nstringKeys.forEach(key => {\n    if (msg.dynamic[key] !== undefined) {\n        template_common.push(`${key}='${msg.dynamic[key]}'`);\n    }\n});\n\n// collect arguments | boolean, integer\nconst otherKeys = [\n    'datetime_in_data',\n    'data_minutes',\n];\n\notherKeys.forEach(key => {\n    if (msg.dynamic[key] !== undefined) {\n        template_common.push(`${key}=${msg.dynamic[key]}`);\n    }\n});\n\n// copy common items\ntemplate_cheapest = [...template_common];\ntemplate_expensive = [...template_common];\ntemplate_all = [...template_common];\n\n// collect arguments | cheapest specific\ntemplate_cheapest.push(`hours=${cheapest_hrs}`);\n// template_cheapest.push(`include_tomorrow=true`);\ntemplate_cheapest.push(`mode=\"all\"`);\n\n// collect arguments | expensive specific\ntemplate_expensive.push(`hours=${expensive_hrs}`);\n// template_expensive.push(`include_tomorrow=true`);\ntemplate_expensive.push(`lowest=false`);\ntemplate_expensive.push(`mode=\"all\"`);\n\n// collect all hours | via extra call\ntemplate_all.push(`hours=\"all\"`);\ntemplate_all.push(`include_tomorrow=true`);\ntemplate_all.push(`mode=\"all\"`);\n\n/**\n * Formats an array of strings into a single string:\n * - Each item starts with 4 spaces.\n * - Each item ends with a comma, except the last one.\n * - Items are separated by a newline.\n */\nfunction formatTemplateArray(array) {\n    if (!array || array.length === 0) {\n        return \"\";\n    }\n\n    const indent = \"    \"; \n\n    const formatted_lines = array.map((element, index) => {\n        const suffix = (index < array.length - 1) ? \",\" : \"\";\n        return `${indent}${element}${suffix}`;\n    });\n\n    return formatted_lines.join('\\n');\n}\n\n// generate string templates\nconst template_cheapest_string = formatTemplateArray(template_cheapest);\nconst template_expensive_string = formatTemplateArray(template_expensive);\nconst template_all_string = formatTemplateArray(template_all);\n\n// done\nmsg.dynamic.template_cheapest = `${template_start}${template_cheapest_string}${template_end}`;\nmsg.dynamic.template_expensive = `${template_start}${template_expensive_string}${template_end}`;\nmsg.dynamic.template_all = `${template_start}${template_all_string}${template_end}`;\n\nreturn msg;",
         "outputs": 1,
@@ -11924,18 +7976,18 @@
         "y": 600,
         "wires": [
             [
-                "efdc5a416dca1c46",
-                "4a12c6ba9d98964e",
-                "3467770b596d2cd0",
-                "b54dfd2aee8114c4"
+                "f29836ea1ad52e46",
+                "0c9bbea87173e613",
+                "f96ee4126963036f",
+                "8d5144b097aa6422"
             ]
         ]
     },
     {
-        "id": "efdc5a416dca1c46",
+        "id": "f29836ea1ad52e46",
         "type": "debug",
-        "z": "99f6e455efa54b3a",
-        "g": "101917fb25d567d6",
+        "z": "c11340415b97b938",
+        "g": "b974ba39dc7d0bca",
         "name": "Template cheapest",
         "active": false,
         "tosidebar": true,
@@ -11950,10 +8002,10 @@
         "wires": []
     },
     {
-        "id": "4a12c6ba9d98964e",
+        "id": "0c9bbea87173e613",
         "type": "debug",
-        "z": "99f6e455efa54b3a",
-        "g": "101917fb25d567d6",
+        "z": "c11340415b97b938",
+        "g": "b974ba39dc7d0bca",
         "name": "Template expensive",
         "active": false,
         "tosidebar": true,
@@ -11968,10 +8020,10 @@
         "wires": []
     },
     {
-        "id": "3467770b596d2cd0",
+        "id": "f96ee4126963036f",
         "type": "change",
-        "z": "99f6e455efa54b3a",
-        "g": "101917fb25d567d6",
+        "z": "c11340415b97b938",
+        "g": "b974ba39dc7d0bca",
         "name": "Set",
         "rules": [
             {
@@ -11991,15 +8043,15 @@
         "y": 660,
         "wires": [
             [
-                "9a68105b2f6b975c"
+                "34fd784e608d9d54"
             ]
         ]
     },
     {
-        "id": "653113bbb5c213d4",
+        "id": "7957ba42cec8c33a",
         "type": "change",
-        "z": "99f6e455efa54b3a",
-        "g": "101917fb25d567d6",
+        "z": "c11340415b97b938",
+        "g": "b974ba39dc7d0bca",
         "name": "Set",
         "rules": [
             {
@@ -12019,15 +8071,15 @@
         "y": 720,
         "wires": [
             [
-                "eee4e7f3304c26ed"
+                "64ac7813f1f8a906"
             ]
         ]
     },
     {
-        "id": "19e3d0f158f3b578",
+        "id": "6859674ee5e989a3",
         "type": "change",
-        "z": "99f6e455efa54b3a",
-        "g": "101917fb25d567d6",
+        "z": "c11340415b97b938",
+        "g": "b974ba39dc7d0bca",
         "name": "Cleanup",
         "rules": [
             {
@@ -12045,15 +8097,15 @@
         "y": 840,
         "wires": [
             [
-                "5908484fee20f236"
+                "bcc7f47c83e1d999"
             ]
         ]
     },
     {
-        "id": "a51a5cd98b789771",
+        "id": "1d6b8b8a07984e20",
         "type": "debug",
-        "z": "99f6e455efa54b3a",
-        "g": "b4d8861efefe4972",
+        "z": "c11340415b97b938",
+        "g": "b2852c433afeb8cc",
         "name": "Log: activate 'debug mode' first",
         "active": true,
         "tosidebar": true,
@@ -12068,10 +8120,10 @@
         "wires": []
     },
     {
-        "id": "8c704ab4f125c10c",
+        "id": "96620bc320d1f41e",
         "type": "server-state-changed",
-        "z": "99f6e455efa54b3a",
-        "g": "1c58bd73aef4538b",
+        "z": "c11340415b97b938",
+        "g": "8c1deab0e5e6f11a",
         "name": "User input",
         "server": "176d29a.6f648d6",
         "version": 6,
@@ -12126,15 +8178,15 @@
         "y": 340,
         "wires": [
             [
-                "2f4467e62db0af59"
+                "de7507b8e2f9830e"
             ]
         ]
     },
     {
-        "id": "cce5bc49088b006a",
+        "id": "7b84c64641b09f1a",
         "type": "switch",
-        "z": "99f6e455efa54b3a",
-        "g": "1c58bd73aef4538b",
+        "z": "c11340415b97b938",
+        "g": "8c1deab0e5e6f11a",
         "name": "Source selected?",
         "property": "dynamic.data_source",
         "propertyType": "msg",
@@ -12155,19 +8207,19 @@
         "y": 380,
         "wires": [
             [
-                "5389042290f78ae7"
+                "9777db5a45b20653"
             ],
             [
-                "6c27d2c4744e1e45"
+                "877fbda0b5917a30"
             ]
         ],
         "l": false
     },
     {
-        "id": "0ab721b9d58d102f",
+        "id": "d68ab5d71946310d",
         "type": "debug",
-        "z": "99f6e455efa54b3a",
-        "g": "1c58bd73aef4538b",
+        "z": "c11340415b97b938",
+        "g": "8c1deab0e5e6f11a",
         "name": "Not set",
         "active": true,
         "tosidebar": false,
@@ -12182,10 +8234,10 @@
         "wires": []
     },
     {
-        "id": "d94fa194cae868ad",
+        "id": "143c21e7820f372f",
         "type": "api-call-service",
-        "z": "99f6e455efa54b3a",
-        "g": "b4d8861efefe4972",
+        "z": "c11340415b97b938",
+        "g": "b2852c433afeb8cc",
         "name": "Avg cheap tariff",
         "server": "176d29a.6f648d6",
         "version": 7,
@@ -12214,10 +8266,10 @@
         ]
     },
     {
-        "id": "687936a77e0f906d",
+        "id": "9684b85dd4952a26",
         "type": "api-call-service",
-        "z": "99f6e455efa54b3a",
-        "g": "b4d8861efefe4972",
+        "z": "c11340415b97b938",
+        "g": "b2852c433afeb8cc",
         "name": "Avg expensive tariff",
         "server": "176d29a.6f648d6",
         "version": 7,
@@ -12246,10 +8298,10 @@
         ]
     },
     {
-        "id": "6b2377c655bd05fc",
+        "id": "a0270d19a585a526",
         "type": "api-call-service",
-        "z": "99f6e455efa54b3a",
-        "g": "b4d8861efefe4972",
+        "z": "c11340415b97b938",
+        "g": "b2852c433afeb8cc",
         "name": "Avg delta",
         "server": "176d29a.6f648d6",
         "version": 7,
@@ -12278,10 +8330,10 @@
         ]
     },
     {
-        "id": "53c357f45b14b295",
+        "id": "958ddb0cbeb390ca",
         "type": "api-current-state",
-        "z": "99f6e455efa54b3a",
-        "g": "b4d8861efefe4972",
+        "z": "c11340415b97b938",
+        "g": "b2852c433afeb8cc",
         "name": "Threshold delta",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -12324,15 +8376,15 @@
         "y": 1020,
         "wires": [
             [
-                "f68514fd61cab5ee"
+                "d8aabf7646c2f302"
             ]
         ]
     },
     {
-        "id": "5389042290f78ae7",
+        "id": "9777db5a45b20653",
         "type": "change",
-        "z": "99f6e455efa54b3a",
-        "g": "1c58bd73aef4538b",
+        "z": "c11340415b97b938",
+        "g": "8c1deab0e5e6f11a",
         "name": "Set dynamic strategy to null",
         "rules": [
             {
@@ -12352,15 +8404,15 @@
         "y": 340,
         "wires": [
             [
-                "0ab721b9d58d102f"
+                "d68ab5d71946310d"
             ]
         ]
     },
     {
-        "id": "ca1888369786df2c",
+        "id": "8f3c1e64dd9cd8c1",
         "type": "debug",
-        "z": "99f6e455efa54b3a",
-        "g": "f4d47a8395e2352b",
+        "z": "c11340415b97b938",
+        "g": "066f5b1fcc1b752c",
         "name": "All data",
         "active": true,
         "tosidebar": true,
@@ -12375,10 +8427,10 @@
         "wires": []
     },
     {
-        "id": "9ef13a670cc957eb",
+        "id": "b793788cb3a23b5c",
         "type": "debug",
-        "z": "99f6e455efa54b3a",
-        "g": "8738b26b32fee4e0",
+        "z": "c11340415b97b938",
+        "g": "2d3ed289b08737e5",
         "name": "Complete msg",
         "active": true,
         "tosidebar": true,
@@ -12393,10 +8445,10 @@
         "wires": []
     },
     {
-        "id": "d90bac11be9193dd",
+        "id": "11b8c0e6011b9efb",
         "type": "change",
-        "z": "99f6e455efa54b3a",
-        "g": "d3c9838fd79f66ff",
+        "z": "c11340415b97b938",
+        "g": "1e4d2d34b639b7f8",
         "name": "Trace",
         "rules": [
             {
@@ -12416,16 +8468,16 @@
         "y": 200,
         "wires": [
             [
-                "3688acf38b3e7b48"
+                "9fa38679952970f8"
             ]
         ],
         "info": "Attaches a breadcrumb trace to the msg\r\nso the user can reconstruct which route has\r\nbeen traveled"
     },
     {
-        "id": "26b26089165ee47f",
+        "id": "0942c21d9a7aaefa",
         "type": "function",
-        "z": "99f6e455efa54b3a",
-        "g": "72b9126748df875e",
+        "z": "c11340415b97b938",
+        "g": "d145546c4cfb1e34",
         "name": "Selected",
         "func": "// Logger\nconst log = global.get(\"logger\");\nlog(this,`${msg.target} strategy`);\n\n// Status\nnode.status({fill:\"green\",shape:\"dot\",text:`${msg.target}`});\n\nreturn msg;",
         "outputs": 1,
@@ -12438,15 +8490,15 @@
         "y": 180,
         "wires": [
             [
-                "72dfc4f99ef6204b"
+                "72965df35ce116d9"
             ]
         ]
     },
     {
-        "id": "7aa7aa85cef5da6f",
+        "id": "d02eb043d62a6c0f",
         "type": "catch",
-        "z": "99f6e455efa54b3a",
-        "g": "00ac5116c0a59044",
+        "z": "c11340415b97b938",
+        "g": "a5103e4dc49c5cff",
         "name": "",
         "scope": null,
         "uncaught": true,
@@ -12454,16 +8506,16 @@
         "y": 320,
         "wires": [
             [
-                "ac8806a4ebf78a24"
+                "1a7066daead2a07c"
             ]
         ],
         "l": false
     },
     {
-        "id": "ac8806a4ebf78a24",
+        "id": "1a7066daead2a07c",
         "type": "function",
-        "z": "99f6e455efa54b3a",
-        "g": "00ac5116c0a59044",
+        "z": "c11340415b97b938",
+        "g": "a5103e4dc49c5cff",
         "name": "Unhandled Exception",
         "func": "const handle = global.get('unhandledException');\n\nhandle(this);\n\nreturn msg;",
         "outputs": 1,
@@ -12476,16 +8528,16 @@
         "y": 320,
         "wires": [
             [
-                "adbe314017b329a3"
+                "c2f9d4444566824a"
             ]
         ],
         "l": false
     },
     {
-        "id": "adbe314017b329a3",
+        "id": "c2f9d4444566824a",
         "type": "link out",
-        "z": "99f6e455efa54b3a",
-        "g": "00ac5116c0a59044",
+        "z": "c11340415b97b938",
+        "g": "a5103e4dc49c5cff",
         "name": "link out 5",
         "mode": "return",
         "links": [],
@@ -12494,10 +8546,10 @@
         "wires": []
     },
     {
-        "id": "dde6d8513842ee9d",
+        "id": "36a9fb103ce44403",
         "type": "api-current-state",
-        "z": "99f6e455efa54b3a",
-        "g": "b4d8861efefe4972",
+        "z": "c11340415b97b938",
+        "g": "b2852c433afeb8cc",
         "name": "Threshold cheapest",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -12540,15 +8592,15 @@
         "y": 980,
         "wires": [
             [
-                "53c357f45b14b295"
+                "958ddb0cbeb390ca"
             ]
         ]
     },
     {
-        "id": "f68514fd61cab5ee",
+        "id": "d8aabf7646c2f302",
         "type": "api-current-state",
-        "z": "99f6e455efa54b3a",
-        "g": "b4d8861efefe4972",
+        "z": "c11340415b97b938",
+        "g": "b2852c433afeb8cc",
         "name": "Strategy default",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -12591,15 +8643,15 @@
         "y": 1060,
         "wires": [
             [
-                "e4335777aab93c03"
+                "15f02574323644ae"
             ]
         ]
     },
     {
-        "id": "e4335777aab93c03",
+        "id": "15f02574323644ae",
         "type": "api-current-state",
-        "z": "99f6e455efa54b3a",
-        "g": "b4d8861efefe4972",
+        "z": "c11340415b97b938",
+        "g": "b2852c433afeb8cc",
         "name": "Strategy cheapest",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -12642,15 +8694,15 @@
         "y": 1100,
         "wires": [
             [
-                "a4a1979ffbe3c79c"
+                "bc236515982ed0bc"
             ]
         ]
     },
     {
-        "id": "a4a1979ffbe3c79c",
+        "id": "bc236515982ed0bc",
         "type": "api-current-state",
-        "z": "99f6e455efa54b3a",
-        "g": "b4d8861efefe4972",
+        "z": "c11340415b97b938",
+        "g": "b2852c433afeb8cc",
         "name": "Strategy expensive",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -12693,15 +8745,15 @@
         "y": 1140,
         "wires": [
             [
-                "2178a721499737da"
+                "7c23c7e9d9c9c21d"
             ]
         ]
     },
     {
-        "id": "5908484fee20f236",
+        "id": "bcc7f47c83e1d999",
         "type": "function",
-        "z": "99f6e455efa54b3a",
-        "g": "101917fb25d567d6",
+        "z": "c11340415b97b938",
+        "g": "b974ba39dc7d0bca",
         "name": "Cache data source",
         "func": "// logger, usage: log(this, \"\");\nconst log = global.get('logger');\n\nconst dynamicData = msg.dynamic;\n\n// Helper to check for errors in the object\nconst isInvalid = (data) => {\n    if (!data) return true;\n    // Check if the stringified object contains \"error\"\n    return JSON.stringify(data).toLowerCase().includes(\"error\");\n};\n\nif (isInvalid(dynamicData)) {\n    // Explain issue\n    log(this, \"Invalid data received, clearing cache\", \"warn\");\n    // Clear cache\n    flow.set(\"cached_dynamic_data\", undefined);\n} else {\n    // Cache on success\n    log(this, \"Caching `msg.dynamic`\");\n    // Save the entire object to flow context\n    flow.set(\"cached_dynamic_data\", dynamicData);\n}\n\nreturn msg;",
         "outputs": 1,
@@ -12714,15 +8766,15 @@
         "y": 840,
         "wires": [
             [
-                "3a74e3ce419a7fe9"
+                "7cbb8bdd50eaebfb"
             ]
         ]
     },
     {
-        "id": "581802933376d25f",
+        "id": "cac65cdd2a3d5080",
         "type": "catch",
-        "z": "99f6e455efa54b3a",
-        "g": "47b0e8e393df1fc5",
+        "z": "c11340415b97b938",
+        "g": "9f89ee41a453c9a9",
         "name": "Catch group",
         "scope": "group",
         "uncaught": false,
@@ -12730,15 +8782,15 @@
         "y": 580,
         "wires": [
             [
-                "1a25a576362108df"
+                "bb03acd17ff3399c"
             ]
         ]
     },
     {
-        "id": "00f349135fcb047d",
+        "id": "0b12f31ff704ac06",
         "type": "debug",
-        "z": "99f6e455efa54b3a",
-        "g": "47b0e8e393df1fc5",
+        "z": "c11340415b97b938",
+        "g": "9f89ee41a453c9a9",
         "name": "Strategy errors",
         "active": true,
         "tosidebar": true,
@@ -12753,10 +8805,10 @@
         "wires": []
     },
     {
-        "id": "11f4b7e2ce0e31cf",
+        "id": "e8f1c331e2327281",
         "type": "comment",
-        "z": "99f6e455efa54b3a",
-        "g": "47b0e8e393df1fc5",
+        "z": "c11340415b97b938",
+        "g": "9f89ee41a453c9a9",
         "name": "Cheapest Energy Hours - errors",
         "info": "\"No valid sensor found\" if price_data is none and not valid_sensor,\n\"No valid data in {}\".format(sensor) if price_data is none and data == [] and valid_sensor,\n\"No valid data in provided price_data\" if price_data is not none and not valid_price_data,\n\"Time key '{}' not found in data\".format(time_key) if data and time_key not in data[0],\n\"Value key '{}' not found in data\".format(value_key) if data and value_key not in data[0],\n\"Invalid mode '{}' selected\".format(mode) if mode not in modes,\n\"Boolean input expected for include_today, '{}' can not be processed as a boolean\".format(include_today) if include_today | bool(\"\") is not boolean,\n\"Boolean input expected for include_tomorrow, '{}' can not be processed as a boolean\".format(include_tomorrow) if include_tomorrow | bool(\"\") is not boolean,\n\"Boolean input expected for look_ahead, '{}' can not be processed as a boolean\".format(look_ahead) if look_ahead | bool(\"\") is not boolean,\n\"Boolean input expected for lowest, '{}' can not be processed as a boolean\".format(lowest) if lowest | bool(\"\") is not boolean,\n\"Boolean input expected for latest_possible, '{}' can not be processed as a boolean\".format(latest_possible) if latest_possible | bool(\"\") is not boolean,\n\"Numeric input or percentage expected for price_tolerance, '{}' can not be processed as a float or percentage\".format(price_tolerance) if not valid_pt,\n\"Numeric input expected for kwh, '{}' can not be processed as a float\".format(kwh) if kwh is not none and not kwh | is_number,\n\"Selected program '{}' is not available or has no data\".format(program) if program is not none and w is none,\n\"Selected start parameter is after the end parameter\" if start_end and data,\n\"{} hours between start and end, where {} hours are required\".format(end_start, h | round(3)) if not start_end and end_start < h | round(3) and data,\n\"Invalid combination of source data points per hour '{}' and number of weight points '{}'\".format(dp, dph) if all_keys and not wp_check",
         "x": 1150,
@@ -12764,10 +8816,10 @@
         "wires": []
     },
     {
-        "id": "1a25a576362108df",
+        "id": "bb03acd17ff3399c",
         "type": "function",
-        "z": "99f6e455efa54b3a",
-        "g": "47b0e8e393df1fc5",
+        "z": "c11340415b97b938",
+        "g": "9f89ee41a453c9a9",
         "name": "Unhandled Exception",
         "func": "const handle = global.get('unhandledException');\n\nhandle(this);\n\nreturn msg;",
         "outputs": 1,
@@ -12780,16 +8832,16 @@
         "y": 580,
         "wires": [
             [
-                "00f349135fcb047d"
+                "0b12f31ff704ac06"
             ]
         ],
         "l": false
     },
     {
-        "id": "2436febcc68a269d",
+        "id": "3cc700a138b05de6",
         "type": "function",
-        "z": "99f6e455efa54b3a",
-        "g": "1c58bd73aef4538b",
+        "z": "c11340415b97b938",
+        "g": "8c1deab0e5e6f11a",
         "name": "Cache check",
         "func": "// Check if cache can be used or a new call to Data Source is required\nconst log = global.get('logger');\n\n// Retrieve stored data from flow context\nconst previousValues = flow.get(\"previous_sensor_values\") || {};\nconst cachedData = flow.get(\"cached_dynamic_data\");\n\n// Create a string or object to represent current state\nconst currentValues = {\n    src: msg.dynamic.data_source,\n    hc: msg.dynamic.cheapest_hrs,\n    he: msg.dynamic.expensive_hrs\n};\n\n// Compare current with previous (JSON stringify is a quick way to compare objects)\nconst inputsMatch = JSON.stringify(currentValues) === JSON.stringify(previousValues);\n\n// Determine cache hit\nif (inputsMatch && cachedData){\n    // Cache HIT\n    node.status({ fill: \"green\", shape: \"dot\", text: `Cache hit` });\n    log(this,`*CACHE HIT* using stored tariff data`);\n\n    // Attach cached data to the message so following nodes can use it\n    msg.dynamic = cachedData;\n\n    // Output #1\n    return [msg, null];\n\n} else {\n    // Cache MISS\n    node.status({ fill: \"green\", shape: \"ring\", text: `Cache miss: ${JSON.stringify(currentValues) }` });\n\n    // Save current values for the next run\n    flow.set(\"previous_sensor_values\", currentValues);\n    \n    // Output #2\n    return [null, msg];\n}",
         "outputs": 2,
@@ -12802,10 +8854,10 @@
         "y": 420,
         "wires": [
             [
-                "7f7d4df28918e455"
+                "1c88d5249c92d346"
             ],
             [
-                "a13f6c3e2325368e"
+                "33914fdfaa110ba3"
             ]
         ],
         "outputLabels": [
@@ -12814,87 +8866,87 @@
         ]
     },
     {
-        "id": "7f7d4df28918e455",
+        "id": "1c88d5249c92d346",
         "type": "link out",
-        "z": "99f6e455efa54b3a",
-        "g": "1c58bd73aef4538b",
+        "z": "c11340415b97b938",
+        "g": "8c1deab0e5e6f11a",
         "name": "from Cache Check ok",
         "mode": "link",
         "links": [
-            "1da468394e019058"
+            "1dc09a0aae6aa2d7"
         ],
         "x": 1375,
         "y": 400,
         "wires": []
     },
     {
-        "id": "b57872813470a1bf",
+        "id": "34b4b46992036a22",
         "type": "link in",
-        "z": "99f6e455efa54b3a",
-        "g": "101917fb25d567d6",
+        "z": "c11340415b97b938",
+        "g": "b974ba39dc7d0bca",
         "name": "link Fetch from Data Source",
         "links": [
-            "a13f6c3e2325368e"
+            "33914fdfaa110ba3"
         ],
         "x": 295,
         "y": 560,
         "wires": [
             [
-                "c70c81db78db986d"
+                "f69d6b41f3833758"
             ]
         ]
     },
     {
-        "id": "a13f6c3e2325368e",
+        "id": "33914fdfaa110ba3",
         "type": "link out",
-        "z": "99f6e455efa54b3a",
-        "g": "1c58bd73aef4538b",
+        "z": "c11340415b97b938",
+        "g": "8c1deab0e5e6f11a",
         "name": "from Cache Check NoK",
         "mode": "link",
         "links": [
-            "b57872813470a1bf"
+            "34b4b46992036a22"
         ],
         "x": 1375,
         "y": 440,
         "wires": []
     },
     {
-        "id": "1da468394e019058",
+        "id": "1dc09a0aae6aa2d7",
         "type": "link in",
-        "z": "99f6e455efa54b3a",
-        "g": "b4d8861efefe4972",
+        "z": "c11340415b97b938",
+        "g": "b2852c433afeb8cc",
         "name": "link Determine Strategy",
         "links": [
-            "3a74e3ce419a7fe9",
-            "7f7d4df28918e455"
+            "7cbb8bdd50eaebfb",
+            "1c88d5249c92d346"
         ],
         "x": 295,
         "y": 940,
         "wires": [
             [
-                "dde6d8513842ee9d"
+                "36a9fb103ce44403"
             ]
         ]
     },
     {
-        "id": "3a74e3ce419a7fe9",
+        "id": "7cbb8bdd50eaebfb",
         "type": "link out",
-        "z": "99f6e455efa54b3a",
-        "g": "101917fb25d567d6",
+        "z": "c11340415b97b938",
+        "g": "b974ba39dc7d0bca",
         "name": "link out 12",
         "mode": "link",
         "links": [
-            "1da468394e019058"
+            "1dc09a0aae6aa2d7"
         ],
         "x": 635,
         "y": 840,
         "wires": []
     },
     {
-        "id": "65cb86cc40d09a4f",
+        "id": "88e001bdc138d861",
         "type": "function",
-        "z": "99f6e455efa54b3a",
-        "g": "1c58bd73aef4538b",
+        "z": "c11340415b97b938",
+        "g": "8c1deab0e5e6f11a",
         "name": "Clear Cache",
         "func": "// Clear cache\nflow.set(\"cached_dynamic_data\", undefined);\nreturn msg;",
         "outputs": 1,
@@ -12907,16 +8959,16 @@
         "y": 420,
         "wires": [
             [
-                "daaff12efb064bd6"
+                "0eacfd9ccf95222c"
             ]
         ],
         "l": false
     },
     {
-        "id": "3c738f8cc897b9c2",
+        "id": "f8fad8da4ec02e6d",
         "type": "ha-fire-event",
-        "z": "99f6e455efa54b3a",
-        "g": "f4d47a8395e2352b",
+        "z": "c11340415b97b938",
+        "g": "066f5b1fcc1b752c",
         "name": "",
         "server": "176d29a.6f648d6",
         "version": 0,
@@ -12930,10 +8982,10 @@
         ]
     },
     {
-        "id": "9cca1192971396d4",
+        "id": "92916d0b05ad1c8c",
         "type": "api-render-template",
-        "z": "99f6e455efa54b3a",
-        "g": "101917fb25d567d6",
+        "z": "c11340415b97b938",
+        "g": "b974ba39dc7d0bca",
         "name": "All",
         "server": "176d29a.6f648d6",
         "version": 0,
@@ -12946,15 +8998,15 @@
         "y": 780,
         "wires": [
             [
-                "ec7a895564a448a2"
+                "a8ad08cd0c3ddc3d"
             ]
         ]
     },
     {
-        "id": "ec7a895564a448a2",
+        "id": "a8ad08cd0c3ddc3d",
         "type": "json",
-        "z": "99f6e455efa54b3a",
-        "g": "101917fb25d567d6",
+        "z": "c11340415b97b938",
+        "g": "b974ba39dc7d0bca",
         "name": "",
         "property": "dynamic.data_all",
         "action": "obj",
@@ -12963,17 +9015,17 @@
         "y": 780,
         "wires": [
             [
-                "19e3d0f158f3b578",
-                "c2a7fd9e34a495f8"
+                "6859674ee5e989a3",
+                "f624987ffa0e7d13"
             ]
         ],
         "l": false
     },
     {
-        "id": "56dd9fa3c398c149",
+        "id": "1b934ae07c52fa8e",
         "type": "change",
-        "z": "99f6e455efa54b3a",
-        "g": "101917fb25d567d6",
+        "z": "c11340415b97b938",
+        "g": "b974ba39dc7d0bca",
         "name": "Set",
         "rules": [
             {
@@ -12993,15 +9045,15 @@
         "y": 780,
         "wires": [
             [
-                "9cca1192971396d4"
+                "92916d0b05ad1c8c"
             ]
         ]
     },
     {
-        "id": "3266909a51aea110",
+        "id": "a9bcbe42ed707bd0",
         "type": "ha-fire-event",
-        "z": "99f6e455efa54b3a",
-        "g": "101917fb25d567d6",
+        "z": "c11340415b97b938",
+        "g": "b974ba39dc7d0bca",
         "name": "Update energy prices",
         "server": "176d29a.6f648d6",
         "version": 0,
@@ -13015,10 +9067,10 @@
         ]
     },
     {
-        "id": "b54dfd2aee8114c4",
+        "id": "8d5144b097aa6422",
         "type": "debug",
-        "z": "99f6e455efa54b3a",
-        "g": "101917fb25d567d6",
+        "z": "c11340415b97b938",
+        "g": "b974ba39dc7d0bca",
         "name": "Template all",
         "active": false,
         "tosidebar": true,
@@ -13033,10 +9085,10 @@
         "wires": []
     },
     {
-        "id": "c2a7fd9e34a495f8",
+        "id": "f624987ffa0e7d13",
         "type": "function",
-        "z": "99f6e455efa54b3a",
-        "g": "101917fb25d567d6",
+        "z": "c11340415b97b938",
+        "g": "b974ba39dc7d0bca",
         "name": "Convert price",
         "func": "// logger, usage: log(this, \"\");\nconst log = global.get('logger');\n\n// Conversion\nconst CONVERSION_RATE = parseFloat(RED.util.getMessageProperty(msg, \"dynamic.value_conversion\")) || 1;\n\n// Check if the list exists and is an array to prevent errors\nif (msg.dynamic && msg.dynamic.data_all && Array.isArray(msg.dynamic.data_all.list)) {\n    \n    // Create a new array where each value is multiplied\n    if (Array.isArray(msg.dynamic.data_all?.list)) {\n        msg.dynamic.data_all.list = msg.dynamic.data_all.list.map(v => v / CONVERSION_RATE * 100); // cents\n    }\n\n    // Update other fields\n    if (msg.dynamic.data_all?.average) {\n        msg.dynamic.data_all.average = parseInt(msg.dynamic.data_all.average / CONVERSION_RATE * 100); // cents\n    }\n} else {\n    // Do not continue\n    log(this,\"*price data not updated* price data missing\");\n    return null;\n}\n\nreturn msg;",
         "outputs": 1,
@@ -13049,15 +9101,15 @@
         "y": 780,
         "wires": [
             [
-                "3266909a51aea110"
+                "a9bcbe42ed707bd0"
             ]
         ]
     },
     {
-        "id": "401559fcf17d2cc4",
+        "id": "948a83c51a4fc285",
         "type": "inject",
-        "z": "99f6e455efa54b3a",
-        "g": "1c58bd73aef4538b",
+        "z": "c11340415b97b938",
+        "g": "8c1deab0e5e6f11a",
         "name": "Test",
         "props": [
             {
@@ -13079,15 +9131,15 @@
         "y": 460,
         "wires": [
             [
-                "5bd8887b64e21684"
+                "bcc114a3aa31b7e6"
             ]
         ]
     },
     {
-        "id": "5bd8887b64e21684",
+        "id": "bcc114a3aa31b7e6",
         "type": "api-call-service",
-        "z": "99f6e455efa54b3a",
-        "g": "1c58bd73aef4538b",
+        "z": "c11340415b97b938",
+        "g": "8c1deab0e5e6f11a",
         "name": "Debug ON",
         "server": "176d29a.6f648d6",
         "version": 7,
@@ -13120,31 +9172,31 @@
         "y": 460,
         "wires": [
             [
-                "65cb86cc40d09a4f"
+                "88e001bdc138d861"
             ]
         ]
     },
     {
-        "id": "f16e3f6676acc3ca",
+        "id": "e579f66465fbe1a8",
         "type": "link in",
-        "z": "85b49ff0f08a1d72",
-        "g": "15efb03647185f54",
+        "z": "01a80123db086eba",
+        "g": "afb3e9d3ea7099e5",
         "name": "Full stop",
         "links": [],
         "x": 100,
         "y": 160,
         "wires": [
             [
-                "a01a3f848fb689d9"
+                "9cf1e7d4768dd638"
             ]
         ],
         "l": true
     },
     {
-        "id": "1a0c85af80f362a7",
+        "id": "8fbd1f5d09a2eb31",
         "type": "link out",
-        "z": "85b49ff0f08a1d72",
-        "g": "937d5910d3ca1fec",
+        "z": "01a80123db086eba",
+        "g": "c4f1a5d1926361b9",
         "name": "Return",
         "mode": "return",
         "links": [],
@@ -13153,9 +9205,9 @@
         "wires": []
     },
     {
-        "id": "d3200a56c75e7084",
+        "id": "0586abf060509f6e",
         "type": "function",
-        "z": "85b49ff0f08a1d72",
+        "z": "01a80123db086eba",
         "name": "Stop all batteries",
         "func": "// Logger\nconst log = global.get(\"logger\");\nlog(this,`full stop`);\n\n// Process\nlet solution_array = [];\n\n// Add a solution per battery\nmsg.batteries.forEach(battery => {\n    solution_array.push({ id: battery.id, \n    mode: \"stop\", // disengages Marstek Battery\n    power: 0 }); // set power to 0W\n});\n\n// OUTPUT\nmsg.solutions = solution_array;\nreturn msg;",
         "outputs": 1,
@@ -13168,14 +9220,14 @@
         "y": 180,
         "wires": [
             [
-                "1a0c85af80f362a7"
+                "8fbd1f5d09a2eb31"
             ]
         ]
     },
     {
-        "id": "22de06e510c8fdcc",
+        "id": "30aef7431cca05ca",
         "type": "comment",
-        "z": "85b49ff0f08a1d72",
+        "z": "01a80123db086eba",
         "name": "Home Battery Strategy",
         "info": "The `Home Battery Start` flow will call this strategy flow\nby matching the strategy name with the Link In name.\n\nConfigure the Link In node in the Start group.\n\nDon't modify other parts of the Start and End groups.\nThey handle the calling and returning for you.",
         "x": 120,
@@ -13183,10 +9235,10 @@
         "wires": []
     },
     {
-        "id": "2cd3e5bbf2fb8408",
+        "id": "2b281594aea3b7d8",
         "type": "comment",
-        "z": "85b49ff0f08a1d72",
-        "g": "937d5910d3ca1fec",
+        "z": "01a80123db086eba",
+        "g": "c4f1a5d1926361b9",
         "name": "End (readme)",
         "info": "Should return a solution_array of battery objects\n\n## battery object format\n`{{id: string|number, mode: string, power: number}} battery solution`\n- id is an arbitrary battery ID\n- mode is \"stop\", \"charge\", \"discharge\" for Marstek\n- power in Watts\n\n### example array\nreturn this type of solution_array via msg.solutions\n` \nlet solution_array = [];\nsolution_array.push({id:\"M1\", mode: \"charge\", power: 100}); // per battery\nreturn {solutions: solution_array};\n` ",
         "x": 560,
@@ -13194,10 +9246,10 @@
         "wires": []
     },
     {
-        "id": "4441cfcbecac8772",
+        "id": "2c760025651125e3",
         "type": "comment",
-        "z": "85b49ff0f08a1d72",
-        "g": "15efb03647185f54",
+        "z": "01a80123db086eba",
+        "g": "afb3e9d3ea7099e5",
         "name": "Start (readme)",
         "info": "# Setting up your battery strategy flow\n\n## Setup\nName the `Link In node` in this start group exactly after the <select> option configured in your\nselect_input.house_battery_strategy\n\nconfigure select options in:\ninput_select_house_battery_control.yaml\n\n### example\n`house_battery_strategy:\n  name: House Battery Strategy\n  options:\n    - AcmE example`\n\nThe above creates a select option, allowing user to select 'AcmE example'\n\nWhen selected, battery control will search for a flow containing a Link In node\ncalled 'AcmE example' (case sensitive).",
         "x": 110,
@@ -13205,10 +9257,10 @@
         "wires": []
     },
     {
-        "id": "a01a3f848fb689d9",
+        "id": "9cf1e7d4768dd638",
         "type": "change",
-        "z": "85b49ff0f08a1d72",
-        "g": "15efb03647185f54",
+        "z": "01a80123db086eba",
+        "g": "afb3e9d3ea7099e5",
         "name": "Trace",
         "rules": [
             {
@@ -13228,16 +9280,16 @@
         "y": 200,
         "wires": [
             [
-                "d3200a56c75e7084"
+                "0586abf060509f6e"
             ]
         ],
         "info": "Attaches a breadcrumb trace to the msg\r\nso the user can reconstruct which route has\r\nbeen traveled"
     },
     {
-        "id": "6234bf4f764f5240",
+        "id": "a65dfdd83f7ea229",
         "type": "catch",
-        "z": "85b49ff0f08a1d72",
-        "g": "838ed99b2dcae219",
+        "z": "01a80123db086eba",
+        "g": "9462cd98831eae79",
         "name": "",
         "scope": null,
         "uncaught": false,
@@ -13245,16 +9297,16 @@
         "y": 300,
         "wires": [
             [
-                "5ea6762a56cf8b30"
+                "72331d6edaf1531e"
             ]
         ],
         "l": false
     },
     {
-        "id": "5ea6762a56cf8b30",
+        "id": "72331d6edaf1531e",
         "type": "function",
-        "z": "85b49ff0f08a1d72",
-        "g": "838ed99b2dcae219",
+        "z": "01a80123db086eba",
+        "g": "9462cd98831eae79",
         "name": "Unhandled Exception",
         "func": "const handle = global.get('unhandledException');\n\nhandle(this);\n\nreturn msg;",
         "outputs": 1,
@@ -13267,16 +9319,16 @@
         "y": 300,
         "wires": [
             [
-                "7805470f1308113e"
+                "22b854a4f9f53277"
             ]
         ],
         "l": false
     },
     {
-        "id": "7805470f1308113e",
+        "id": "22b854a4f9f53277",
         "type": "link out",
-        "z": "85b49ff0f08a1d72",
-        "g": "838ed99b2dcae219",
+        "z": "01a80123db086eba",
+        "g": "9462cd98831eae79",
         "name": "link out 6",
         "mode": "return",
         "links": [],
@@ -13285,26 +9337,26 @@
         "wires": []
     },
     {
-        "id": "7429f835c9869a7a",
+        "id": "20b59df6a52ece70",
         "type": "link in",
-        "z": "95b545927e70ace9",
-        "g": "e78001626bd9db2e",
+        "z": "1d3cf6be03a635b7",
+        "g": "a3b887bda9320879",
         "name": "Self-consumption",
         "links": [],
         "x": 160,
         "y": 160,
         "wires": [
             [
-                "a529ac673bea2b3c"
+                "8d6a4b253818f114"
             ]
         ],
         "l": true
     },
     {
-        "id": "b49be705a4e166ed",
+        "id": "f4f5c6c083da0d22",
         "type": "comment",
-        "z": "95b545927e70ace9",
-        "g": "e78001626bd9db2e",
+        "z": "1d3cf6be03a635b7",
+        "g": "a3b887bda9320879",
         "name": "Start (readme)",
         "info": "# Setting up your battery strategy flow\n\n## Setup\nName the Link In in this start group exactly after the option configured in your\nselect_input.house_battery_strategy\n\nfound in the file:\ninput_select_house_battery_control.yaml\n\n### example\n`house_battery_strategy:\n  name: House Battery Strategy\n  options:\n    - AcmE example`\n\nWill point to the flow containing a Link In node\ncalled 'AcmE example' (case sensitive).",
         "x": 150,
@@ -13312,9 +9364,9 @@
         "wires": []
     },
     {
-        "id": "22d7f1fce978ccb7",
+        "id": "2eb6bccb361e4040",
         "type": "comment",
-        "z": "95b545927e70ace9",
+        "z": "1d3cf6be03a635b7",
         "name": "Home Battery Strategy",
         "info": "The `Home Battery Start` flow will call this strategy flow\nby matching the strategy name with the Link In name.\n\nConfigure the Link In node in the Start group.\n\nDon't modify other parts of the Start and End groups.\nThey handle the calling and returning for you.",
         "x": 120,
@@ -13322,10 +9374,10 @@
         "wires": []
     },
     {
-        "id": "fc9a79906d48681f",
+        "id": "2a26a1de36f05234",
         "type": "server-state-changed",
-        "z": "95b545927e70ace9",
-        "g": "12e46fccb5802c71",
+        "z": "1d3cf6be03a635b7",
+        "g": "38f99932aad11a50",
         "name": "User Ki change",
         "server": "176d29a.6f648d6",
         "version": 6,
@@ -13376,15 +9428,15 @@
         "y": 100,
         "wires": [
             [
-                "71f8f0471c914c25"
+                "26098bfe361cba5b"
             ]
         ]
     },
     {
-        "id": "71f8f0471c914c25",
+        "id": "26098bfe361cba5b",
         "type": "function",
-        "z": "95b545927e70ace9",
-        "g": "12e46fccb5802c71",
+        "z": "1d3cf6be03a635b7",
+        "g": "38f99932aad11a50",
         "name": "Integral term adjust",
         "func": "// On change of Ki setting\nlet logdata = \"bumpless \";\nlet I_sum = flow.get(\"I_integral_sum\");\nlet Ki = msg.payload || 0;     // Integral gain\nlet Ki_last = context.get(\"house_battery_control_ki_last\")||0;\n\n// if Ki was or has become zero\nif(Ki == 0 || Ki_last == 0){\n    // passify the integral-sum\n    flow.set(\"I_integral_sum\",0);\n    context.set(\"house_battery_control_ki_last\", Ki);\n    logdata += `to/from 0, Ki=${Ki_last} -> ${Ki} | `;\n    // done\n    return { payload: logdata };\n}\n\n// change in Ki\nlet dKi = parseFloat(Ki/Ki_last);\nif(dKi <= 0) dKi = 1; // ignore erroneous changes\n\n// keep I-term constant by compensating the integral-sum for the change in Ki\n// e.g. if Ki got 10% smaller, then integral-sum should increase 10%, to keep the I-term constant\nlet I_sum_new = I_sum / dKi;\nlogdata += `change of I: from ${Ki_last} to ${Ki} (${dKi * 100}%) | `;\n\n// OUTFLOW\nflow.set(\"I_integral_sum\", I_sum_new);\ncontext.set(\"house_battery_control_ki_last\", Ki);\n\n// OUTPUT\nreturn { payload: logdata };",
         "outputs": 1,
@@ -13397,15 +9449,15 @@
         "y": 160,
         "wires": [
             [
-                "83b75b812fff9770"
+                "684f48ed70c30401"
             ]
         ]
     },
     {
-        "id": "eda60b6eb688e118",
+        "id": "05670e160fd72c4d",
         "type": "comment",
-        "z": "95b545927e70ace9",
-        "g": "12e46fccb5802c71",
+        "z": "1d3cf6be03a635b7",
+        "g": "38f99932aad11a50",
         "name": "Bumpless Ki changes",
         "info": "Recalc I-term whenever Ki changes\n\nNote: always be mindful of making changes to control parameters of systems in operation.",
         "x": 1740,
@@ -13413,10 +9465,10 @@
         "wires": []
     },
     {
-        "id": "83b75b812fff9770",
+        "id": "684f48ed70c30401",
         "type": "debug",
-        "z": "95b545927e70ace9",
-        "g": "12e46fccb5802c71",
+        "z": "1d3cf6be03a635b7",
+        "g": "38f99932aad11a50",
         "name": "Logdata",
         "active": false,
         "tosidebar": true,
@@ -13431,10 +9483,10 @@
         "wires": []
     },
     {
-        "id": "2a17f575ab4edb9a",
+        "id": "0b50278f356f3282",
         "type": "switch",
-        "z": "95b545927e70ace9",
-        "g": "0b266d0d6a782396",
+        "z": "1d3cf6be03a635b7",
+        "g": "3ed2a38d76be9667",
         "name": "Check for custom/auto mode",
         "property": "payload",
         "propertyType": "msg",
@@ -13462,24 +9514,24 @@
         "y": 520,
         "wires": [
             [
-                "518ee919cd3efac1",
-                "229a18de6fecdbdf"
+                "7fac9748dd62b6bd",
+                "dd49186b76d0ee0d"
             ],
             [
-                "518ee919cd3efac1",
-                "229a18de6fecdbdf"
+                "7fac9748dd62b6bd",
+                "dd49186b76d0ee0d"
             ],
             [
-                "229a18de6fecdbdf"
+                "dd49186b76d0ee0d"
             ]
         ],
         "l": false
     },
     {
-        "id": "229a18de6fecdbdf",
+        "id": "dd49186b76d0ee0d",
         "type": "debug",
-        "z": "95b545927e70ace9",
-        "g": "0b266d0d6a782396",
+        "z": "1d3cf6be03a635b7",
+        "g": "3ed2a38d76be9667",
         "name": "Master control switch",
         "active": false,
         "tosidebar": true,
@@ -13494,10 +9546,10 @@
         "wires": []
     },
     {
-        "id": "283ec6ca6ed7d7c3",
+        "id": "7cc3ff28dc56daba",
         "type": "server-state-changed",
-        "z": "95b545927e70ace9",
-        "g": "0b266d0d6a782396",
+        "z": "1d3cf6be03a635b7",
+        "g": "3ed2a38d76be9667",
         "name": "Master control mode",
         "server": "176d29a.6f648d6",
         "version": 6,
@@ -13548,15 +9600,15 @@
         "y": 520,
         "wires": [
             [
-                "2a17f575ab4edb9a"
+                "0b50278f356f3282"
             ]
         ]
     },
     {
-        "id": "798c57f1fbed218f",
+        "id": "484f1bf00afa7c93",
         "type": "api-call-service",
-        "z": "95b545927e70ace9",
-        "g": "0b266d0d6a782396",
+        "z": "1d3cf6be03a635b7",
+        "g": "3ed2a38d76be9667",
         "name": "Integral PID to zero",
         "server": "176d29a.6f648d6",
         "version": 7,
@@ -13582,15 +9634,15 @@
         "y": 360,
         "wires": [
             [
-                "328a1037fb53a26b"
+                "fa5b3eb85366eb75"
             ]
         ]
     },
     {
-        "id": "328a1037fb53a26b",
+        "id": "fa5b3eb85366eb75",
         "type": "api-call-service",
-        "z": "95b545927e70ace9",
-        "g": "0b266d0d6a782396",
+        "z": "1d3cf6be03a635b7",
+        "g": "3ed2a38d76be9667",
         "name": "Differential PID to zero",
         "server": "176d29a.6f648d6",
         "version": 7,
@@ -13616,15 +9668,15 @@
         "y": 400,
         "wires": [
             [
-                "5bf6859a2eb3736e"
+                "2373084a62c2feaa"
             ]
         ]
     },
     {
-        "id": "518ee919cd3efac1",
+        "id": "7fac9748dd62b6bd",
         "type": "api-call-service",
-        "z": "95b545927e70ace9",
-        "g": "0b266d0d6a782396",
+        "z": "1d3cf6be03a635b7",
+        "g": "3ed2a38d76be9667",
         "name": "Proportinal PID to zero",
         "server": "176d29a.6f648d6",
         "version": 7,
@@ -13650,15 +9702,15 @@
         "y": 320,
         "wires": [
             [
-                "798c57f1fbed218f"
+                "484f1bf00afa7c93"
             ]
         ]
     },
     {
-        "id": "5bf6859a2eb3736e",
+        "id": "2373084a62c2feaa",
         "type": "api-call-service",
-        "z": "95b545927e70ace9",
-        "g": "0b266d0d6a782396",
+        "z": "1d3cf6be03a635b7",
+        "g": "3ed2a38d76be9667",
         "name": "PID Output to zero",
         "server": "176d29a.6f648d6",
         "version": 7,
@@ -13684,15 +9736,15 @@
         "y": 440,
         "wires": [
             [
-                "101ce775aa237ed9"
+                "da671bc3ae62f046"
             ]
         ]
     },
     {
-        "id": "101ce775aa237ed9",
+        "id": "da671bc3ae62f046",
         "type": "change",
-        "z": "95b545927e70ace9",
-        "g": "0b266d0d6a782396",
+        "z": "1d3cf6be03a635b7",
+        "g": "3ed2a38d76be9667",
         "name": "Integral sum to zero",
         "rules": [
             {
@@ -13715,10 +9767,10 @@
         ]
     },
     {
-        "id": "bc0f60b5ad95db8d",
+        "id": "2fc2aaaf7233eea5",
         "type": "api-current-state",
-        "z": "95b545927e70ace9",
-        "g": "edc2a2a28871c43a",
+        "z": "1d3cf6be03a635b7",
+        "g": "0a55432a91ac4ec8",
         "name": "Target grid consumption",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -13761,16 +9813,16 @@
         "y": 120,
         "wires": [
             [
-                "f340a342d8960dc5"
+                "feac298f995f06c5"
             ]
         ],
         "info": "Set at 0 to strive for zero consumption"
     },
     {
-        "id": "6bf43ec016ed83ac",
+        "id": "b9ab2d12f4d067fa",
         "type": "api-current-state",
-        "z": "95b545927e70ace9",
-        "g": "fbc01f9edcc6842a",
+        "z": "1d3cf6be03a635b7",
+        "g": "ad8b5d8b3606c48b",
         "name": "Hysteresis",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -13813,15 +9865,15 @@
         "y": 120,
         "wires": [
             [
-                "a33b025d071a6e94"
+                "f81b4a5e8214cef1"
             ]
         ]
     },
     {
-        "id": "8a2068076f28f707",
+        "id": "94479d5e6b3261e9",
         "type": "api-current-state",
-        "z": "95b545927e70ace9",
-        "g": "edc2a2a28871c43a",
+        "z": "1d3cf6be03a635b7",
+        "g": "0a55432a91ac4ec8",
         "name": "PID P-value",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -13864,15 +9916,15 @@
         "y": 180,
         "wires": [
             [
-                "83191e5fbcbb4040"
+                "c0be8ba44fcac8ab"
             ]
         ]
     },
     {
-        "id": "83191e5fbcbb4040",
+        "id": "c0be8ba44fcac8ab",
         "type": "api-current-state",
-        "z": "95b545927e70ace9",
-        "g": "edc2a2a28871c43a",
+        "z": "1d3cf6be03a635b7",
+        "g": "0a55432a91ac4ec8",
         "name": "PID I-value",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -13915,15 +9967,15 @@
         "y": 180,
         "wires": [
             [
-                "a26b70853d0c1f33"
+                "aa281f3ee93a6151"
             ]
         ]
     },
     {
-        "id": "a26b70853d0c1f33",
+        "id": "aa281f3ee93a6151",
         "type": "api-current-state",
-        "z": "95b545927e70ace9",
-        "g": "edc2a2a28871c43a",
+        "z": "1d3cf6be03a635b7",
+        "g": "0a55432a91ac4ec8",
         "name": "PID D-value",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -13966,15 +10018,15 @@
         "y": 180,
         "wires": [
             [
-                "a4a00c57b5d69453"
+                "409106894fab910f"
             ]
         ]
     },
     {
-        "id": "a33b025d071a6e94",
+        "id": "f81b4a5e8214cef1",
         "type": "function",
-        "z": "95b545927e70ace9",
-        "g": "fbc01f9edcc6842a",
+        "z": "1d3cf6be03a635b7",
+        "g": "ad8b5d8b3606c48b",
         "name": "Advanced settings",
         "func": "// 1. Hard coded advanced settings (flow level)\nflow.set(\"has_soc_charging_limiter\", true);         // slows charging from 95% to 100% to improve battery life\nflow.set(\"has_reverse_priority_discharge\", true);   // Prioritize discharging and charging the same battery when possible\nflow.set(\"master_gain\", 1);                         // Gain scheduling. Not Implemented!\n\n// 2. Configurable advanced settings (msg level)\nmsg.advanced_settings ||= {}; // creates 'advanced_settings' if it does net yet exist\nlet mas = msg.advanced_settings;\n\n// disable charge or dicharge solutions and changes them to stop solutions\nRED.util.setMessageProperty(msg,\"advanced_settings.discharge_disabled\", mas.discharge_disabled ?? false);\nRED.util.setMessageProperty(msg,\"advanced_settings.charge_disabled\", mas.charge_disabled ?? false);\n// The nullish coalescing (??) operator is a logical operator that returns its right-hand side operand when its left-hand side operand is null or undefined\n\n// 3. continue\nreturn msg;\n\n// Notes for home battery tinkerer friends:\n// Using RED.util.getMessageProperty / RED.util.setMessageProperty is more performant and safe.\n// If any part of the path (\"foo.bar\") is missing, it will return 'undefined' without throwing an error.",
         "outputs": 1,
@@ -13987,15 +10039,15 @@
         "y": 180,
         "wires": [
             [
-                "81656e1f7dd92ea6"
+                "9cd824ee2bb19cb0"
             ]
         ]
     },
     {
-        "id": "a4a00c57b5d69453",
+        "id": "409106894fab910f",
         "type": "api-current-state",
-        "z": "95b545927e70ace9",
-        "g": "fbc01f9edcc6842a",
+        "z": "1d3cf6be03a635b7",
+        "g": "ad8b5d8b3606c48b",
         "name": "Idle time before Stop",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -14038,15 +10090,15 @@
         "y": 80,
         "wires": [
             [
-                "6bf43ec016ed83ac"
+                "b9ab2d12f4d067fa"
             ]
         ]
     },
     {
-        "id": "449b488ed26a70f9",
+        "id": "32a4f7483671ea38",
         "type": "comment",
-        "z": "95b545927e70ace9",
-        "g": "d893e2f37a24c25c",
+        "z": "1d3cf6be03a635b7",
+        "g": "9a620a2a2f96288f",
         "name": "Setpoint ramping / damping",
         "info": "",
         "x": 460,
@@ -14054,10 +10106,10 @@
         "wires": []
     },
     {
-        "id": "81656e1f7dd92ea6",
+        "id": "9cd824ee2bb19cb0",
         "type": "api-current-state",
-        "z": "95b545927e70ace9",
-        "g": "d893e2f37a24c25c",
+        "z": "1d3cf6be03a635b7",
+        "g": "9a620a2a2f96288f",
         "name": "Error signal dampening",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -14100,15 +10152,15 @@
         "y": 340,
         "wires": [
             [
-                "97b610266a045131"
+                "8a56bf61cd0c2bdf"
             ]
         ]
     },
     {
-        "id": "97b610266a045131",
+        "id": "8a56bf61cd0c2bdf",
         "type": "api-current-state",
-        "z": "95b545927e70ace9",
-        "g": "d893e2f37a24c25c",
+        "z": "1d3cf6be03a635b7",
+        "g": "9a620a2a2f96288f",
         "name": "Output signal dampening",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -14151,15 +10203,15 @@
         "y": 380,
         "wires": [
             [
-                "8e1df3c6f38c1053"
+                "f0173fe22d480af0"
             ]
         ]
     },
     {
-        "id": "8e1df3c6f38c1053",
+        "id": "f0173fe22d480af0",
         "type": "function",
-        "z": "95b545927e70ace9",
-        "g": "d893e2f37a24c25c",
+        "z": "1d3cf6be03a635b7",
+        "g": "9a620a2a2f96288f",
         "name": "Set: Error signal",
         "func": "// INPUTS\nlet P1_error_last = Number(context.get(\"p1_error_last\"))||0; // last error signal level in W\nlet dampening = Number(flow.get(\"house_battery_control_error_signal_dampening\")) || 0; // 0% - 100%\ndampening = dampening / 100; // to Number\n\n// Process Variable (PV) currently measured grid power, Setpoint (SP) desired grid power, set 0 for NoM\nvar P1_power = msg.grid_power; // PV: consume is positive, supply to grid is negative\nvar P1_setpoint = Number(RED.util.getMessageProperty(msg,\"house_target_grid_consumption_in_w\")); // SP: target value\n\n// Calc error signal\nlet P1_error_unfiltered = P1_setpoint - P1_power;\n\n// Simple averaging filter\nlet P1_error_filtered = (1 - dampening) * P1_error_unfiltered + (dampening) * P1_error_last;\n\n// OUTFLOW\ncontext.set(\"p1_error_last\", P1_error_filtered);\n\n// OUTPUT\nmsg.grid_error = P1_error_filtered; // W (watt), error signal = SP - PV\nreturn msg;",
         "outputs": 1,
@@ -14172,15 +10224,15 @@
         "y": 420,
         "wires": [
             [
-                "02779588813f2ea1"
+                "cf38a2aa88332648"
             ]
         ]
     },
     {
-        "id": "4f756da9c8b272a5",
+        "id": "e55ec15da0d697fa",
         "type": "comment",
-        "z": "95b545927e70ace9",
-        "g": "75642cb0b65d0e1e",
+        "z": "1d3cf6be03a635b7",
+        "g": "d9ae5f41bc83da9b",
         "name": "Bumpless target grid consumption",
         "info": "The error value is used by default to calculate the derivative.\nWhen the target grid consumption (tgc) is changed, the system is takes the derivative of the process variable instead.\nThis prevents irratic behavior during sudden changes of the error or setpoint value.\n\ne.g. you change the setpoint from 0 to 100W \nThe error would make an instantanious jump and cause a huge derivative-term.\nThe pv stays continous and fluent.\n\nAfter 1 control tick the derivative is taken from error again.\nUntil the `tgc` is changed again.",
         "x": 780,
@@ -14188,10 +10240,10 @@
         "wires": []
     },
     {
-        "id": "5791fc8607b08141",
+        "id": "ac2fa01660cc55a4",
         "type": "function",
-        "z": "95b545927e70ace9",
-        "g": "75642cb0b65d0e1e",
+        "z": "1d3cf6be03a635b7",
+        "g": "d9ae5f41bc83da9b",
         "name": "Derivative PV",
         "func": "var P1_power = msg.grid_power||0;\nvar P1_last_power = Number(context.get(\"p1_last_power\")) ||0;\n\n// PV derivative\nvar p1_derivative = P1_power - P1_last_power; // devided by unity seconds\n\n// OUTFLOW\ncontext.set(\"p1_last_power\", P1_power);\n\n// OUTPUT\nmsg.grid_derivative = p1_derivative;\nreturn msg;",
         "outputs": 1,
@@ -14204,15 +10256,15 @@
         "y": 500,
         "wires": [
             [
-                "d1b3c520513823b2"
+                "e694349a6ea76737"
             ]
         ]
     },
     {
-        "id": "b6f33bcaec258e9c",
+        "id": "21add7c0e2d45e21",
         "type": "switch",
-        "z": "95b545927e70ace9",
-        "g": "75642cb0b65d0e1e",
+        "z": "1d3cf6be03a635b7",
+        "g": "d9ae5f41bc83da9b",
         "name": "Target grid consumption unchanged",
         "property": "house_target_grid_consumption_in_w",
         "propertyType": "flow",
@@ -14235,18 +10287,18 @@
         "y": 480,
         "wires": [
             [
-                "d341286c1d683cd6"
+                "820f84951c511215"
             ],
             [
-                "5791fc8607b08141"
+                "ac2fa01660cc55a4"
             ]
         ]
     },
     {
-        "id": "d341286c1d683cd6",
+        "id": "820f84951c511215",
         "type": "function",
-        "z": "95b545927e70ace9",
-        "g": "75642cb0b65d0e1e",
+        "z": "1d3cf6be03a635b7",
+        "g": "d9ae5f41bc83da9b",
         "name": "Derivative Error",
         "func": "var P1_error = msg.grid_error||0;\nvar P1_last_error = Number(context.get(\"p1_last_error\")) ||0;\n\n// Error derivative\n// note: error = -PV\n// note: for simplicity we assume 1 second time steps\nlet p1_derivative = -(P1_error - P1_last_error); // devided by unity seconds\n\n// OUTFLOW\ncontext.set(\"p1_last_error\", P1_error);\n\n// OUTPUT\nmsg.grid_derivative = p1_derivative;\nreturn msg;",
         "outputs": 1,
@@ -14259,15 +10311,15 @@
         "y": 460,
         "wires": [
             [
-                "d1b3c520513823b2"
+                "e694349a6ea76737"
             ]
         ]
     },
     {
-        "id": "d1b3c520513823b2",
+        "id": "e694349a6ea76737",
         "type": "function",
-        "z": "95b545927e70ace9",
-        "g": "75642cb0b65d0e1e",
+        "z": "1d3cf6be03a635b7",
+        "g": "d9ae5f41bc83da9b",
         "name": "Derivative final value",
         "func": "\nreturn msg;",
         "outputs": 1,
@@ -14280,15 +10332,15 @@
         "y": 480,
         "wires": [
             [
-                "8dd243f68e522803"
+                "1ed3fc7e029faf20"
             ]
         ]
     },
     {
-        "id": "02779588813f2ea1",
+        "id": "cf38a2aa88332648",
         "type": "function",
-        "z": "95b545927e70ace9",
-        "g": "d8c94b15828961e5",
+        "z": "1d3cf6be03a635b7",
+        "g": "502610763c97d762",
         "name": "Deadband (15W)",
         "func": "// Deadband\n// Stop processing if error is within .. Watt of target grid consumption.\n// This to reduce CPU loads \n\n// Logger\nconst log = global.get(\"logger\");\n\n// P1\nlet P1_error = msg.grid_error; // Watt\nlet P1_deadband = 15; // Watt\n\n// TODO\n// based on last 'assignable power' and current error, if (error > assignable power) the system will never enter the deadband. And keep calculating each interation.\n// however since we don't know if the is the assignable power will change, until we calculate the Control Value / load balancer\n// we could end up in a deadlock if we simply stop execution here, based on assignable power alone.\n\n// Within Deadband\nif(Math.abs(P1_error) < P1_deadband) {\n    // stop processing\n    node.status({fill:\"yellow\",shape:\"dot\",text:`Halt, ${Math.round(Math.abs(P1_error))} W`});\n    log(this, `**Stopped processing**ðŸŒ¿power saving, ${Math.round(Math.abs(P1_error))} W is within deadband of ${P1_deadband} W`);\n    msg.payload = 'halted by deadband';\n    return msg;\n} \n\n// Outside deadband\nnode.status({fill:\"green\",shape:\"dot\",text:`Pass, ${Math.round(Math.abs(P1_error))} W`});\nreturn msg;\n",
         "outputs": 1,
@@ -14301,15 +10353,15 @@
         "y": 340,
         "wires": [
             [
-                "8ec51e53b2d0f9bb"
+                "61b64f336cfe23f6"
             ]
         ]
     },
     {
-        "id": "8dd243f68e522803",
+        "id": "1ed3fc7e029faf20",
         "type": "function",
-        "z": "95b545927e70ace9",
-        "g": "6697a3fa1010723e",
+        "z": "1d3cf6be03a635b7",
+        "g": "29995cd0b0073ccd",
         "name": "Calculate corrections",
         "func": "// Logger\nvar logdata = \"\"; // deprecated\nconst log = global.get(\"logger\");\n\n// Timing\nlet time_last = context.get('time_last') || Date.now(); // Milliseconds\nlet time_current = Date.now(); // Milliseconds\nlet time_delta = (time_current - time_last) / 1000; // Convert to seconds\n// note: due to inherent 1 sec intervals of P1 meter we omit dt terms. This is mostly for bug checking and optimizations.\n\n// Batteries\nvar B_power = msg.batteries_total_power; // charging is positive, discharging negative\nvar anti_windup_threshold = Number(flow.get(\"batteries_total_assignable_power\")) || 0; // max available charge/discharge power.\n\n// Process Variable (PV) currently measured grid power, Setpoint (SP) desired grid power, set 0 for NoM\nvar P1_power = msg.grid_power; // PV: consume is positive, supply to grid is negative\nvar P1_setpoint = flow.get(\"house_target_grid_consumption_in_w\"); // SP: target value\nvar P1_error = msg.grid_error;  // W (watt), error signal = SP - PV\nvar P1_derivative = msg.grid_derivative; // Derivative of PV, not the error\n\n// PID values\nvar Kp = flow.get(\"house_battery_control_kp\") || 0.75;  // Proportional gain\nvar Ki = flow.get(\"house_battery_control_ki\") || 0;     // Integral gain        Ki = Kp/Ti\nvar Kd = flow.get(\"house_battery_control_kd\") || 0;     // Derivative gain      Kd = Kp*Td\n\n// helpers\nvar I_integral_sum = context.get('I_integral_sum') || 0;\nvar Gm = flow.get(\"master_gain\")||1; // gain scheduling\n\n// optimizations\nvar hysteresis = flow.get(\"house_battery_control_hysteresis_in_w\"); // W (watt)\n\n// advanced settings\nconst isDischargeDisabled = RED.util.getMessageProperty(msg,\"advanced_settings.discharge_disabled\");\nconst isChargeDisabled = RED.util.getMessageProperty(msg,\"advanced_settings.charge_disabled\");\n\n// -- PID regulator --\n// Proportional term\nlet p_term = Gm * Kp * P1_error;\n\n// Integral term\nlet integral_max = 0;\nif (Ki > 0) {\n    // Integral term | integrate\n    I_integral_sum += P1_error; \n    // Integral term | apply anti-windup\n    integral_max = anti_windup_threshold / Ki; // the anti-windup value is set to the current controlable range of the batteries, given by the previous load balancer calculations\n    I_integral_sum = Math.min(Math.max(I_integral_sum, -integral_max), integral_max);\n} else {\n    // If Ki is 0, keep everything 0\n    I_integral_sum = 0;\n    integral_max = 0;\n}\n\n// Integral term | the term\nlet i_term = Ki * I_integral_sum;\n\n// Integral term | explain\nlogdata += `anti_windup_threshold=${anti_windup_threshold}, integral_max=${integral_max}| `; // deprecated\n\n// Differential term\nlet d_term = Gm * Kd * (-P1_derivative); // omitted '/time_delta'. inherent P1 refresh fequency.\n\n// Total PID output\nvar PID_output = p_term + i_term + d_term; // W (watt), the control input for the battery packs\n\n// Charging or Discharging states\nvar B_was_charging = context.get(\"batteries_charging_last\") || false;\nvar B_is_charging = PID_output > 0 ? true : false;\n\n// Explain\nlogdata += `U(${time_delta}s)[${PID_output}] = P(${Kp})[${p_term}] + I(${Ki})[${i_term}] + D(${Kd})[${d_term}] | `; // deprecated\nlog(this,`**PID Controller**`);\nlog(this,`Step size: ${time_delta} s`);\nif(Kp == 0 && Ki == 0 && Kd == 0) {\n    log(this, `<font color=\"orange\">**Controller disabled**</font> All PID gains are 0. Choose a PID preset or set gains > 0.`,\"warn\");\n} else {\n    // log(this, `P-term: ${Math.floor(p_term)} W @ P-gain ${Kp}`);\n    // log(this, `I-term: ${Math.floor(i_term)} W @ I-gain ${Ki} (max. ${anti_windup_threshold} W)`);\n    // log(this, `D-term: ${Math.floor(d_term)} W @ D-gain ${Kd}`);\n    log(this, `**P** ${Math.floor(p_term)} W @ gain ${Kp}<br>**I** ${Math.floor(i_term)} W @ gain ${Ki} (max. ${anti_windup_threshold} W)<br>**D** ${Math.floor(d_term)} W @ gain ${Kd}`);\n    log(this, `**PID ${B_is_charging ? 'Charge' : 'Discharge'}:** ${Math.floor(p_term)} + ${Math.floor(i_term)} + ${Math.floor(d_term)} = **${Math.round(PID_output)} Watt**`);\n}\n\n// Only one of the advanced settings below can be active at once.\n// Advanced setting | discharge disabled\nif(isDischargeDisabled && !B_is_charging) {\n    // log explain\n    logdata += `Discharging disabled, PID unwound U(${time_delta})[0]=0+0+0 | `;\n    log(this,'**PID capped at 0**. Discharge is disabled in this strategy'); // via `msg.advanced_settings`\n    // Set all PID terms to 0 and unwind integral sum\n    PID_output = 0;\n    p_term = 0;\n    i_term = 0;\n    d_term = 0;\n    I_integral_sum = 0; // unwind\n    // maintain charge scenario\n    B_is_charging = true;\n    \n// Advanced setting | charge disabled\n} else if (isChargeDisabled && B_is_charging) {\n    // log explain\n    logdata += `Charging disabled, PID unwound U(${time_delta})[0]=0+0+0 | `;\n    log(this,'**PID capped at 0**. Charge is disabled in this strategy'); // via `msg.advanced_settings`\n    // Set all PID terms to 0 and unwind integral sum\n    PID_output = 0;\n    p_term = 0;\n    i_term = 0;\n    d_term = 0;\n    I_integral_sum = 0; // unwind\n    // maintain discharge scenario\n    B_is_charging = false;\n\n// Advanced setting | hysteresis\n} else if \n// prevents excessive switching between (dis)charge mode around the zero point.\n// if new PID_output lies within hysteresis, it will not switch charge mode. \n// set hysteresis to 0, to apply no hysteresis\n(B_is_charging !== B_was_charging && Math.abs(PID_output) < hysteresis){\n    // log explain\n    logdata += `Hysteresis prevented charge mode switch from ${B_was_charging ? \"charging\" : \"discharging\"} to ${B_is_charging ? \"charging\" : \"discharging\"} as ${Math.abs(PID_output)}W <= ${hysteresis}(hyst) | `;\n    log(this,`Hysteresis prevented charge mode switch from ${B_was_charging ? \"charging\" : \"discharging\"} to ${B_is_charging ? \"charging\" : \"discharging\"} as ${Math.abs(PID_output)}W <= ${hysteresis}(hyst)`);\n    // prevent negative charging or positive discharging values (not allowed)\n    PID_output = (PID_output < 0 && B_is_charging) || ((PID_output > 0 && !B_is_charging)) ? 0 : PID_output;\n    // maintain previous scenario\n    B_is_charging = B_was_charging;\n} \n\n// save for next iteration\ncontext.set(\"batteries_charging_last\", B_is_charging); //boolean\n\n// OUTFLOW\ncontext.set(\"time_last\", Date.now());\ncontext.set(\"I_integral_sum\", I_integral_sum);\n\n// OUTPUT\nRED.util.setMessageProperty(msg, \"batteries_charging\", B_is_charging, true);\nRED.util.setMessageProperty(msg, \"I_integral_sum\", I_integral_sum,true);\nmsg.payload = Number(PID_output);\n\nreturn [msg, // payload = PID_output\n        { payload: Number(P1_error)},\n        { payload: parseFloat(p_term)},\n        { payload: parseFloat(i_term)},\n        { payload: parseFloat(d_term)},\n        { payload: B_is_charging},\n        { payload: logdata }];",
         "outputs": 7,
@@ -14322,25 +10374,25 @@
         "y": 700,
         "wires": [
             [
-                "543f350e89a68994"
+                "3236985a34b149bc"
             ],
             [
-                "307d9f53546e14f0"
+                "329f3cbc671249c7"
             ],
             [
-                "b657bfbf3a7eb6a1"
+                "a4adb78b5507e5fc"
             ],
             [
-                "4ccbd6efdd4517e1"
+                "62f1b3c9088c874c"
             ],
             [
-                "53b2cc35ca8e6dfd"
+                "749c0a41454bc101"
             ],
             [
-                "82c2a3ffbf8605c9"
+                "9db7ba7db486e683"
             ],
             [
-                "05ada452851c2f54"
+                "c915c89572f2197d"
             ]
         ],
         "inputLabels": [
@@ -14348,10 +10400,10 @@
         ]
     },
     {
-        "id": "05ada452851c2f54",
+        "id": "c915c89572f2197d",
         "type": "debug",
-        "z": "95b545927e70ace9",
-        "g": "6697a3fa1010723e",
+        "z": "1d3cf6be03a635b7",
+        "g": "29995cd0b0073ccd",
         "name": "Logdata",
         "active": false,
         "tosidebar": true,
@@ -14366,10 +10418,10 @@
         "wires": []
     },
     {
-        "id": "307d9f53546e14f0",
+        "id": "329f3cbc671249c7",
         "type": "api-call-service",
-        "z": "95b545927e70ace9",
-        "g": "6697a3fa1010723e",
+        "z": "1d3cf6be03a635b7",
+        "g": "29995cd0b0073ccd",
         "name": "Error Signal",
         "server": "176d29a.6f648d6",
         "version": 7,
@@ -14395,15 +10447,15 @@
         "y": 760,
         "wires": [
             [
-                "33bacec3a2296d98"
+                "0a41c005e73b7f1f"
             ]
         ]
     },
     {
-        "id": "53c69b2484613a04",
+        "id": "8421219bb5e59589",
         "type": "api-call-service",
-        "z": "95b545927e70ace9",
-        "g": "6697a3fa1010723e",
+        "z": "1d3cf6be03a635b7",
+        "g": "29995cd0b0073ccd",
         "name": "PID Output",
         "server": "176d29a.6f648d6",
         "version": 7,
@@ -14429,15 +10481,15 @@
         "y": 700,
         "wires": [
             [
-                "703ad985bc335fec"
+                "0849b31850b001e2"
             ]
         ]
     },
     {
-        "id": "325a6ee7699c88ba",
+        "id": "453e21c86b6336d6",
         "type": "api-call-service",
-        "z": "95b545927e70ace9",
-        "g": "6697a3fa1010723e",
+        "z": "1d3cf6be03a635b7",
+        "g": "29995cd0b0073ccd",
         "name": "Proportinal term",
         "server": "176d29a.6f648d6",
         "version": 7,
@@ -14466,10 +10518,10 @@
         ]
     },
     {
-        "id": "a4f127c2ab2fe440",
+        "id": "e01b146cd708f9f5",
         "type": "api-call-service",
-        "z": "95b545927e70ace9",
-        "g": "6697a3fa1010723e",
+        "z": "1d3cf6be03a635b7",
+        "g": "29995cd0b0073ccd",
         "name": "Integral term",
         "server": "176d29a.6f648d6",
         "version": 7,
@@ -14498,10 +10550,10 @@
         ]
     },
     {
-        "id": "a6a12718d0113a94",
+        "id": "4a75544e000d0772",
         "type": "api-call-service",
-        "z": "95b545927e70ace9",
-        "g": "6697a3fa1010723e",
+        "z": "1d3cf6be03a635b7",
+        "g": "29995cd0b0073ccd",
         "name": "Differential term",
         "server": "176d29a.6f648d6",
         "version": 7,
@@ -14530,10 +10582,10 @@
         ]
     },
     {
-        "id": "dd6ff843a07fb171",
+        "id": "ed2ad4363b1754e8",
         "type": "debug",
-        "z": "95b545927e70ace9",
-        "g": "6697a3fa1010723e",
+        "z": "1d3cf6be03a635b7",
+        "g": "29995cd0b0073ccd",
         "name": "Charging",
         "active": false,
         "tosidebar": false,
@@ -14548,10 +10600,10 @@
         "wires": []
     },
     {
-        "id": "703ad985bc335fec",
+        "id": "0849b31850b001e2",
         "type": "smooth",
-        "z": "95b545927e70ace9",
-        "g": "6697a3fa1010723e",
+        "z": "1d3cf6be03a635b7",
+        "g": "29995cd0b0073ccd",
         "name": "",
         "property": "payload",
         "action": "sd",
@@ -14563,15 +10615,15 @@
         "y": 700,
         "wires": [
             [
-                "3a45b91f874f978f"
+                "c654cb2271f9ada1"
             ]
         ]
     },
     {
-        "id": "3a45b91f874f978f",
+        "id": "c654cb2271f9ada1",
         "type": "api-call-service",
-        "z": "95b545927e70ace9",
-        "g": "6697a3fa1010723e",
+        "z": "1d3cf6be03a635b7",
+        "g": "29995cd0b0073ccd",
         "name": "PID deviation",
         "server": "176d29a.6f648d6",
         "version": 7,
@@ -14600,10 +10652,10 @@
         ]
     },
     {
-        "id": "33bacec3a2296d98",
+        "id": "0a41c005e73b7f1f",
         "type": "smooth",
-        "z": "95b545927e70ace9",
-        "g": "6697a3fa1010723e",
+        "z": "1d3cf6be03a635b7",
+        "g": "29995cd0b0073ccd",
         "name": "",
         "property": "payload",
         "action": "sd",
@@ -14615,15 +10667,15 @@
         "y": 760,
         "wires": [
             [
-                "d938d61eb9bd05e3"
+                "41f9974be9e16501"
             ]
         ]
     },
     {
-        "id": "d938d61eb9bd05e3",
+        "id": "41f9974be9e16501",
         "type": "api-call-service",
-        "z": "95b545927e70ace9",
-        "g": "6697a3fa1010723e",
+        "z": "1d3cf6be03a635b7",
+        "g": "29995cd0b0073ccd",
         "name": "Error deviation",
         "server": "176d29a.6f648d6",
         "version": 7,
@@ -14652,10 +10704,10 @@
         ]
     },
     {
-        "id": "543f350e89a68994",
+        "id": "3236985a34b149bc",
         "type": "function",
-        "z": "95b545927e70ace9",
-        "g": "6697a3fa1010723e",
+        "z": "1d3cf6be03a635b7",
+        "g": "29995cd0b0073ccd",
         "name": "Output dampening",
         "func": "// INPUT\nlet PID_unfiltered = msg.payload; // W Watt\nlet PID_last = context.get(\"PID_last\")||0; // W watt\nlet PID_damp = Number(flow.get(\"house_battery_control_pid_output_dampening\"))||0; // 0% - 100%\nPID_damp = PID_damp/100; // to Number\n\n// simple averaging filter\nlet PID_filtered = (1-PID_damp)*PID_unfiltered + (PID_damp)*PID_last;\n\n// OUTFLOW\ncontext.set(\"PID_last\", PID_filtered);\n\n// OUTPUT\nmsg.payload = Number(PID_filtered)\nreturn msg;",
         "outputs": 1,
@@ -14668,15 +10720,15 @@
         "y": 660,
         "wires": [
             [
-                "79782f0fafc42800"
+                "62b85cc02674c18b"
             ]
         ]
     },
     {
-        "id": "79782f0fafc42800",
+        "id": "62b85cc02674c18b",
         "type": "function",
-        "z": "95b545927e70ace9",
-        "g": "6697a3fa1010723e",
+        "z": "1d3cf6be03a635b7",
+        "g": "29995cd0b0073ccd",
         "name": "Output failsafe",
         "func": "// INFLOW\nlet maxCharge = msg.batteries_max_charge_power||undefined;\nlet maxDischarge = msg.batteries_max_discharge_power||undefined;\nlet isCharging = msg.batteries_charging||undefined;\nlet PID_output = msg.payload; // Watt\n\n// No failsafe\nif (maxCharge === undefined || maxDischarge == undefined) {\n    node.status({ fill: \"red\", shape: \"dot\", text: \"disabled\" });\n    node.warn(`Output Failsafe is INACTIVE. Max charge or discharge limits are undefined`);\n    // continue without safeguard\n    return msg;\n} \n\n// limit\nlet limit = 0;\n\n// charging state unknown\nif(isCharging === undefined) {\n    // limit on lowest of charge / discharge\n    limit = Math.min(maxCharge,maxDischarge);    \n}\n// charging state known\nlimit = isCharging ? maxCharge : maxDischarge;\n\n// Safe output\nif (PID_output <= limit){\n    node.status({ fill: \"green\", shape: \"dot\", text: \"safe\" });\n    return msg;\n} \n\n// Unsafe, limit output\nnode.status({ fill: \"yellow\", shape: \"ring\", text: \"power limiting\" });\nmsg.payload = Number(limit);\nreturn msg;",
         "outputs": 1,
@@ -14689,16 +10741,16 @@
         "y": 660,
         "wires": [
             [
-                "c93703549f08db02",
-                "53c69b2484613a04"
+                "15e1815e0781a8a6",
+                "8421219bb5e59589"
             ]
         ]
     },
     {
-        "id": "4ccbd6efdd4517e1",
+        "id": "62f1b3c9088c874c",
         "type": "rbe",
-        "z": "95b545927e70ace9",
-        "g": "6697a3fa1010723e",
+        "z": "1d3cf6be03a635b7",
+        "g": "29995cd0b0073ccd",
         "name": "on change",
         "func": "rbe",
         "gap": "",
@@ -14711,15 +10763,15 @@
         "y": 880,
         "wires": [
             [
-                "a4f127c2ab2fe440"
+                "e01b146cd708f9f5"
             ]
         ]
     },
     {
-        "id": "c93703549f08db02",
+        "id": "15e1815e0781a8a6",
         "type": "function",
-        "z": "95b545927e70ace9",
-        "g": "6d773e100cbddf8f",
+        "z": "1d3cf6be03a635b7",
+        "g": "c0422f307e2b7a3f",
         "name": "Load distribution",
         "func": "// Logger\nconst log = global.get(\"logger\");\nlog(this,\"**PID load distribution**\");\n\n// INPUT\nvar batteries = msg.batteries; // Battery configuration as provided by `Home Batteries IO` flow\nvar isCharging = msg.batteries_charging; // Are we in a battery charging scenario?\nvar hasChargingLimiter = flow.get(\"has_soc_charging_limiter\") || false; // Battery life improvement\nvar hasReverseDischargePriority = flow.get(\"has_reverse_priority_discharge\") || false; // Prioritize (dis)charging the same battery\nconst isDischargeDisabled = RED.util.getMessageProperty(msg,\"advanced_settings.discharge_disabled\"); // Disallow discharging?\n\n// how much power do the batteries need to compensate?\nconst unassigned_power_initial = Math.round(Math.abs(msg.payload)); // Power in W to compensate using batteries\nvar unassigned_power = unassigned_power_initial; // Before distribution\nlog(this,`How much power do the batteries need to compensate: ${unassigned_power} W`);\n\n// inits \nvar solution_array = []; // load distribution solutions\nvar batteries_total_assignable_power = 0; // Current max. available total (dis)charge power. Exceeding this max should trigger the anti-windup routine for the Integral terms\n\n// enums\nconst CMODE = {\n    STOP: \"stop\", // Marstek batteries disconnect a relay when this is set or Power is 0W\n    CHARGE: \"charge\",\n    DISCHARGE: \"discharge\"\n}\n\n/**\n** Battery life improvement (slow charge near max SoC)\n* @param {number} soc\n* @param {number} max_power\n*/\nfunction chargingLimiter(soc, max_power) {\n    // Must be greater than zero\n    let limitedPower = Math.max(0, max_power); \n\n    // Limit charge at high SoC\n    if (hasChargingLimiter) {\n        if (soc >= 99)      limitedPower = Math.min(1000, limitedPower);\n        else if (soc >= 95) limitedPower = Math.min(1500, limitedPower);\n    }\n    return limitedPower;\n}\n\n/**\n* battery life improvement (disconnects battery only if the battery is not used for ... seconds)\n* @param {string | number} batteryID\n* @returns {{id: string|number, mode: string, power: number}} battery solution\n*/\nfunction getStopSolution(batteryID) {\n    // idle time, before stop is given to inverter relay.\n    let time_idle_minimum = flow.get(\"idle_time_minutes\")*60*1000||0; // Milliseconds\n\n    // retrieve last registered active times for each battery based on their ids\n    let lasttime_active = context.get(\"lasttime_active\");\n    \n    // battery exists in register \n    if(lasttime_active[batteryID] !== undefined){\n        // timing\n        let time_last = lasttime_active[batteryID]; // Milliseconds \n        let time_now = Date.now();                  // Milliseconds \n        let time_idle = (time_now - time_last); // Milliseconds\n        \n        // battery is ready for STOP\n        if (time_idle >= time_idle_minimum) {\n            log(this,`Battery ${batteryID} [STOP]: 0 Watt and disconnect relay.`);\n            return {id: batteryID, mode: CMODE.STOP, power:0}; // STOP or 0 Watt disconnects relay\n        }\n        \n        // battery is kept IDLE, while awaiting minimum inactive time\n        log(this,`Battery ${batteryID} [IDLE]: 1 Watt for ${Math.round((time_idle_minimum-time_idle)/1000)}s. Keep relay engaged.`);\n        return { id: batteryID, mode: isCharging ? CMODE.CHARGE : CMODE.DISCHARGE, power: 1 }; // 1 Watt keeps battery IDLE, keeping relay engaged\n    }\n\n    // battery missing in register\n    log(this,`Battery ${batteryID} [IDLE]: unknown last active time`);\n    return getActiveSolution(batteryID, 1); // set a last active time and engage idle state\n}\n\n/**\n* Get battery solution and register a last active time.\n* @param {any} batteryID\n* @param {number} assigned_power\n* @returns {{id: string|number, mode: string, power: number}} battery solution\n*/\nfunction getActiveSolution(batteryID, assigned_power){\n    // register battery as active\n    let lasttime_active = context.get(\"lasttime_active\")||[]; // last registered active times for each battery based on their ids\n    lasttime_active[batteryID] = Date.now();\n    context.set(\"lasttime_active\", lasttime_active);\n\n    // solution\n    return {\n        id: batteryID,\n        mode: isCharging ? CMODE.CHARGE : CMODE.DISCHARGE,\n        power: Math.round(assigned_power)\n    };\n}\n\n// -- BATTERY DISCHARGE PRIORITY\nif (!isCharging && hasReverseDischargePriority) {\n   batteries.reverse();\n}\n\n// -- LOAD BALANCER --\nbatteries.forEach((/** @type {{ id: any; soc: number; soc_min: number; soc_max: number; rs485: string; charging_max: number; discharging_max: any; }} */ battery) => {\n    \n    // Explain\n    log(this, `Battery ${battery.id}: ${battery.soc}% (min: ${battery.soc_min}%, max: ${battery.soc_max}%) ; RS485: ${battery.rs485=='enable'?'OK':'Nok'}`);\n\n    // track if the battery should be skipped and why\n    let skipReason = null;\n    if (battery.rs485 !== \"enable\") {\n        skipReason = `Battery ${battery.id} [SKIP]: skipped because RS485 is not 'enable'`;\n    } else if (isCharging && battery.soc >= battery.soc_max) {\n        skipReason = `Battery ${battery.id} [SKIP]: skipped because SoC (${battery.soc}%) >= Max (${battery.soc_max}%) while charging`;\n    } else if (!isCharging && battery.soc <= battery.soc_min) {\n        skipReason = `Battery ${battery.id} [SKIP]: skipped because SoC (${battery.soc}%) <= Min (${battery.soc_min}%) while discharging`;\n    } else if (!isCharging && isDischargeDisabled) {\n        skipReason = `Battery ${battery.id} [SKIP]: skipped, discharging was disabled via msg property`;\n    }\n\n    // battery NOT AVAIABLE, skip via soft stop\n    if (skipReason !== null) {\n        log(this, skipReason);                      // communicate reason\n        let solution = getStopSolution(battery.id); // get a soft stop solution for this battery\n        solution_array.push(solution);              // add solution, do not update last active time.\n        // next battery\n        return; \n    }\n\n    // battery is AVAILABLE, assign power\n    let battery_assignable_power = isCharging ? chargingLimiter(battery.soc, battery.charging_max) : battery.discharging_max;\n    let assign = Math.min(unassigned_power, battery_assignable_power);\n    \n    // select solution\n    var solution;\n    if (assign <= 0 ) {\n        // no power solution\n        solution = getStopSolution(battery.id); // a soft stop solution\n        assign = 0;\n    } else {\n        // assigned power solution\n        solution = getActiveSolution(battery.id, Math.round(assign));\n    }\n    solution_array.push(solution);\n    \n    // Explain: charge limiting\n    if(unassigned_power > battery_assignable_power && battery_assignable_power < battery.charging_max) {\n        log(this,`Charging limited to protect battery (${battery.soc}%): ${battery.charging_max}W -> ${battery_assignable_power}W`);\n    }\n    // Explain: solution result\n    log(this, `<font color=\"#009ac7\">Battery ${solution.id}</font>: assigned to ${solution.mode} with ${solution.power}W / ${isCharging ? battery.charging_max : battery.discharging_max }W max.`)\n\n    // remaining power to assign\n    unassigned_power -= assign;\n    batteries_total_assignable_power += Number(battery_assignable_power);\n});\n\n// battery discharge priority - put solutions back in initial order\nif (!isCharging && hasReverseDischargePriority) {\n    solution_array.reverse();\n}\n\n// store solutions in msg\nRED.util.setMessageProperty(msg, \"solutions\", solution_array,true);\n// store remaining load distribution results and PID_OUPUT in msg\nRED.util.setMessageProperty(msg, \"pid.output\", unassigned_power_initial, true); // the dampenend & filtered PID_output equals the load requirement\nRED.util.setMessageProperty(msg, \"pid.load\", unassigned_power_initial, true); \nRED.util.setMessageProperty(msg, \"pid.load_capacity\", batteries_total_assignable_power, true);\nRED.util.setMessageProperty(msg, \"pid.load_assigned\", parseInt(unassigned_power_initial - unassigned_power), true);\nRED.util.setMessageProperty(msg, \"pid.load_unassigned\", unassigned_power,true);\n\n// OUTFLOW\nflow.set(\"batteries_total_assignable_power\", batteries_total_assignable_power); // this is set for the anti-windup calculation in the earlier 'calculate corrections' node, which will pick this up during next iteration.\n\n// OUTPUT\nreturn msg; // to Home Battery flow",
         "outputs": 1,
@@ -14732,8 +10784,8 @@
         "y": 1160,
         "wires": [
             [
-                "6322e003511c0da0",
-                "db62188eeb09a5fe"
+                "edcb4ef7c4ac95a7",
+                "535f8ee333775a18"
             ]
         ],
         "inputLabels": [
@@ -14741,10 +10793,10 @@
         ]
     },
     {
-        "id": "6322e003511c0da0",
+        "id": "edcb4ef7c4ac95a7",
         "type": "debug",
-        "z": "95b545927e70ace9",
-        "g": "6d773e100cbddf8f",
+        "z": "1d3cf6be03a635b7",
+        "g": "c0422f307e2b7a3f",
         "name": "Load distribution",
         "active": false,
         "tosidebar": true,
@@ -14759,10 +10811,10 @@
         "wires": []
     },
     {
-        "id": "8ec51e53b2d0f9bb",
+        "id": "61b64f336cfe23f6",
         "type": "switch",
-        "z": "95b545927e70ace9",
-        "g": "d8c94b15828961e5",
+        "z": "1d3cf6be03a635b7",
+        "g": "502610763c97d762",
         "name": "Pass or Halt",
         "property": "payload",
         "propertyType": "msg",
@@ -14785,18 +10837,18 @@
         "y": 340,
         "wires": [
             [
-                "e8de4c019d4e5868"
+                "01dedefe1e7ce9db"
             ],
             [
-                "b6f33bcaec258e9c"
+                "21add7c0e2d45e21"
             ]
         ]
     },
     {
-        "id": "db62188eeb09a5fe",
+        "id": "535f8ee333775a18",
         "type": "link out",
-        "z": "95b545927e70ace9",
-        "g": "13d8169172cbd977",
+        "z": "1d3cf6be03a635b7",
+        "g": "805ff27a624e0a7f",
         "name": "Return",
         "mode": "return",
         "links": [],
@@ -14805,10 +10857,10 @@
         "wires": []
     },
     {
-        "id": "7c60441a294b5a22",
+        "id": "104d4c3148b8cd19",
         "type": "comment",
-        "z": "95b545927e70ace9",
-        "g": "13d8169172cbd977",
+        "z": "1d3cf6be03a635b7",
+        "g": "805ff27a624e0a7f",
         "name": "End (readme)",
         "info": "Should return a solution_array of battery objects\n\n## battery object format\n`{{id: string|number, mode: string, power: number}} battery solution`\n- id is an arbitrary battery ID\n- mode is \"stop\", \"charge\", \"discharge\" for Marstek\n- power in Watts\n\n### example array\nreturn this type of solution_array via msg.solutions\n` \nlet solution_array = [];\nsolution_array.push({id:\"M1\", mode: \"charge\", power: 100}); // per battery\nreturn {solutions: solution_array};\n` ",
         "x": 170,
@@ -14816,14 +10868,14 @@
         "wires": []
     },
     {
-        "id": "e8de4c019d4e5868",
+        "id": "01dedefe1e7ce9db",
         "type": "link out",
-        "z": "95b545927e70ace9",
-        "g": "d8c94b15828961e5",
+        "z": "1d3cf6be03a635b7",
+        "g": "502610763c97d762",
         "name": "go to End",
         "mode": "link",
         "links": [
-            "920bae464a1f958b"
+            "7512d630ea96b3e9"
         ],
         "x": 1090,
         "y": 340,
@@ -14834,27 +10886,27 @@
         "l": true
     },
     {
-        "id": "920bae464a1f958b",
+        "id": "7512d630ea96b3e9",
         "type": "link in",
-        "z": "95b545927e70ace9",
-        "g": "13d8169172cbd977",
+        "z": "1d3cf6be03a635b7",
+        "g": "805ff27a624e0a7f",
         "name": "link to End",
         "links": [
-            "e8de4c019d4e5868"
+            "01dedefe1e7ce9db"
         ],
         "x": 105,
         "y": 1240,
         "wires": [
             [
-                "db62188eeb09a5fe"
+                "535f8ee333775a18"
             ]
         ]
     },
     {
-        "id": "1de249bcde8d065a",
+        "id": "99a492d34dc9cbf7",
         "type": "api-call-service",
-        "z": "95b545927e70ace9",
-        "g": "6697a3fa1010723e",
+        "z": "1d3cf6be03a635b7",
+        "g": "29995cd0b0073ccd",
         "name": "Is charging",
         "server": "176d29a.6f648d6",
         "version": 7,
@@ -14881,10 +10933,10 @@
         ]
     },
     {
-        "id": "920232e0b3ca3daf",
+        "id": "a762a06160c44f50",
         "type": "function",
-        "z": "95b545927e70ace9",
-        "g": "6697a3fa1010723e",
+        "z": "1d3cf6be03a635b7",
+        "g": "29995cd0b0073ccd",
         "name": "Config action",
         "func": "const value = msg.payload;\nconst target = \"input_boolean.house_battery_control_is_charging\";\n\nmsg.payload = {\n    \"action\": value?\"input_boolean.turn_on\":\"input_boolean.turn_off\",\n    \"target\": {\n        \"entity_id\": [target]\n    },\n    \"data\": {}\n}\n\n\nreturn msg;",
         "outputs": 1,
@@ -14897,15 +10949,15 @@
         "y": 1000,
         "wires": [
             [
-                "1de249bcde8d065a"
+                "99a492d34dc9cbf7"
             ]
         ]
     },
     {
-        "id": "28fdc66b87c47def",
+        "id": "8a4036338bcd1979",
         "type": "switch",
-        "z": "95b545927e70ace9",
-        "g": "edc2a2a28871c43a",
+        "z": "1d3cf6be03a635b7",
+        "g": "0a55432a91ac4ec8",
         "name": "Target",
         "property": "house_target_grid_consumption_in_w",
         "propertyType": "msg",
@@ -14924,18 +10976,18 @@
         "y": 120,
         "wires": [
             [
-                "5762198fbde44006"
+                "fc7ebb59ccc630d1"
             ],
             [
-                "bc0f60b5ad95db8d"
+                "2fc2aaaf7233eea5"
             ]
         ]
     },
     {
-        "id": "a5dd4127a91f05bf",
+        "id": "c4e8dbbe77422199",
         "type": "debug",
-        "z": "95b545927e70ace9",
-        "g": "edc2a2a28871c43a",
+        "z": "1d3cf6be03a635b7",
+        "g": "0a55432a91ac4ec8",
         "name": "Target",
         "active": true,
         "tosidebar": false,
@@ -14950,10 +11002,10 @@
         "wires": []
     },
     {
-        "id": "80d79876154eca1b",
+        "id": "7735be058403fdf1",
         "type": "server-state-changed",
-        "z": "95b545927e70ace9",
-        "g": "0b266d0d6a782396",
+        "z": "1d3cf6be03a635b7",
+        "g": "3ed2a38d76be9667",
         "name": "Strategy changes",
         "server": "176d29a.6f648d6",
         "version": 6,
@@ -15005,15 +11057,15 @@
         "y": 340,
         "wires": [
             [
-                "ce067d9bbd24b919"
+                "09456f5a8948bd0e"
             ]
         ]
     },
     {
-        "id": "ce067d9bbd24b919",
+        "id": "09456f5a8948bd0e",
         "type": "switch",
-        "z": "95b545927e70ace9",
-        "g": "0b266d0d6a782396",
+        "z": "1d3cf6be03a635b7",
+        "g": "3ed2a38d76be9667",
         "name": "",
         "property": "payload",
         "propertyType": "msg",
@@ -15031,16 +11083,16 @@
         "y": 340,
         "wires": [
             [
-                "518ee919cd3efac1"
+                "7fac9748dd62b6bd"
             ]
         ],
         "l": false
     },
     {
-        "id": "5b2021e7f5061d68",
+        "id": "11841edbd6eb50aa",
         "type": "server-state-changed",
-        "z": "95b545927e70ace9",
-        "g": "0b266d0d6a782396",
+        "z": "1d3cf6be03a635b7",
+        "g": "3ed2a38d76be9667",
         "name": "Full stop trigger",
         "server": "176d29a.6f648d6",
         "version": 6,
@@ -15091,15 +11143,15 @@
         "y": 420,
         "wires": [
             [
-                "478c3ce913f5e339"
+                "cc3e4dc8fecd193a"
             ]
         ]
     },
     {
-        "id": "478c3ce913f5e339",
+        "id": "cc3e4dc8fecd193a",
         "type": "switch",
-        "z": "95b545927e70ace9",
-        "g": "0b266d0d6a782396",
+        "z": "1d3cf6be03a635b7",
+        "g": "3ed2a38d76be9667",
         "name": "",
         "property": "payload",
         "propertyType": "msg",
@@ -15117,16 +11169,16 @@
         "y": 420,
         "wires": [
             [
-                "518ee919cd3efac1"
+                "7fac9748dd62b6bd"
             ]
         ],
         "l": false
     },
     {
-        "id": "b657bfbf3a7eb6a1",
+        "id": "a4adb78b5507e5fc",
         "type": "rbe",
-        "z": "95b545927e70ace9",
-        "g": "6697a3fa1010723e",
+        "z": "1d3cf6be03a635b7",
+        "g": "29995cd0b0073ccd",
         "name": "on change",
         "func": "rbe",
         "gap": "",
@@ -15139,15 +11191,15 @@
         "y": 820,
         "wires": [
             [
-                "325a6ee7699c88ba"
+                "453e21c86b6336d6"
             ]
         ]
     },
     {
-        "id": "53b2cc35ca8e6dfd",
+        "id": "749c0a41454bc101",
         "type": "rbe",
-        "z": "95b545927e70ace9",
-        "g": "6697a3fa1010723e",
+        "z": "1d3cf6be03a635b7",
+        "g": "29995cd0b0073ccd",
         "name": "on change",
         "func": "rbe",
         "gap": "",
@@ -15160,15 +11212,15 @@
         "y": 940,
         "wires": [
             [
-                "a6a12718d0113a94"
+                "4a75544e000d0772"
             ]
         ]
     },
     {
-        "id": "82c2a3ffbf8605c9",
+        "id": "9db7ba7db486e683",
         "type": "rbe",
-        "z": "95b545927e70ace9",
-        "g": "6697a3fa1010723e",
+        "z": "1d3cf6be03a635b7",
+        "g": "29995cd0b0073ccd",
         "name": "on change",
         "func": "rbe",
         "gap": "",
@@ -15181,16 +11233,16 @@
         "y": 1000,
         "wires": [
             [
-                "920232e0b3ca3daf",
-                "dd6ff843a07fb171"
+                "a762a06160c44f50",
+                "ed2ad4363b1754e8"
             ]
         ]
     },
     {
-        "id": "a529ac673bea2b3c",
+        "id": "8d6a4b253818f114",
         "type": "change",
-        "z": "95b545927e70ace9",
-        "g": "e78001626bd9db2e",
+        "z": "1d3cf6be03a635b7",
+        "g": "a3b887bda9320879",
         "name": "Trace",
         "rules": [
             {
@@ -15210,16 +11262,16 @@
         "y": 200,
         "wires": [
             [
-                "28fdc66b87c47def"
+                "8a4036338bcd1979"
             ]
         ],
         "info": "Attaches a breadcrumb trace to the msg\r\nso the user can reconstruct which route has\r\nbeen traveled"
     },
     {
-        "id": "28404ee9bffbd9bc",
+        "id": "e53efde4b8bb20c7",
         "type": "catch",
-        "z": "95b545927e70ace9",
-        "g": "37009bd6e266d3b6",
+        "z": "1d3cf6be03a635b7",
+        "g": "78c50df35fe0a532",
         "name": "",
         "scope": null,
         "uncaught": false,
@@ -15227,16 +11279,16 @@
         "y": 320,
         "wires": [
             [
-                "b7696ce52882d505"
+                "f5fe682fec29feb2"
             ]
         ],
         "l": false
     },
     {
-        "id": "b7696ce52882d505",
+        "id": "f5fe682fec29feb2",
         "type": "function",
-        "z": "95b545927e70ace9",
-        "g": "37009bd6e266d3b6",
+        "z": "1d3cf6be03a635b7",
+        "g": "78c50df35fe0a532",
         "name": "Unhandled Exception",
         "func": "const handle = global.get('unhandledException');\n\nhandle(this);\n\nreturn msg;",
         "outputs": 1,
@@ -15249,16 +11301,16 @@
         "y": 320,
         "wires": [
             [
-                "62f0daf706ea8d51"
+                "b50ed0719809245a"
             ]
         ],
         "l": false
     },
     {
-        "id": "62f0daf706ea8d51",
+        "id": "b50ed0719809245a",
         "type": "link out",
-        "z": "95b545927e70ace9",
-        "g": "37009bd6e266d3b6",
+        "z": "1d3cf6be03a635b7",
+        "g": "78c50df35fe0a532",
         "name": "link out 7",
         "mode": "return",
         "links": [],
@@ -15267,9 +11319,9 @@
         "wires": []
     },
     {
-        "id": "0c2a7f2df9733dd4",
+        "id": "391979eb1410a23a",
         "type": "comment",
-        "z": "45268219e4d1f409",
+        "z": "8ba5b00d69c6f447",
         "name": "Home Battery Strategy",
         "info": "The `Home Battery Start` flow will call this strategy flow\nby matching the strategy name with the Link In name.\n\nConfigure the Link In node in the Start group.\n\nDon't modify other parts of the Start and End groups.\nThey handle the calling and returning for you.",
         "x": 140,
@@ -15277,26 +11329,26 @@
         "wires": []
     },
     {
-        "id": "1cf0ee59d698937c",
+        "id": "6fa309f87b9a4311",
         "type": "link in",
-        "z": "45268219e4d1f409",
-        "g": "246292447922fcbb",
+        "z": "8ba5b00d69c6f447",
+        "g": "86d607ed8d206722",
         "name": "Sell",
         "links": [],
         "x": 110,
         "y": 220,
         "wires": [
             [
-                "5e424902e2b3c300"
+                "335427d0817d394d"
             ]
         ],
         "l": true
     },
     {
-        "id": "c317e60b806e44b0",
+        "id": "9fa4c0553e3fc69a",
         "type": "comment",
-        "z": "45268219e4d1f409",
-        "g": "246292447922fcbb",
+        "z": "8ba5b00d69c6f447",
+        "g": "86d607ed8d206722",
         "name": "Start (readme)",
         "info": "# Setting up your battery strategy flow\n\n## Setup\nName the `Link In node` in this start group exactly after the <select> option configured in your\nselect_input.house_battery_strategy\n\nconfigure select options in:\ninput_select_house_battery_control.yaml\n\n### example\n`house_battery_strategy:\n  name: House Battery Strategy\n  options:\n    - AcmE example`\n\nThe above creates a select option, allowing user to select 'AcmE example'\n\nWhen selected, battery control will search for a flow containing a Link In node\ncalled 'AcmE example' (case sensitive).",
         "x": 130,
@@ -15304,10 +11356,10 @@
         "wires": []
     },
     {
-        "id": "5e424902e2b3c300",
+        "id": "335427d0817d394d",
         "type": "change",
-        "z": "45268219e4d1f409",
-        "g": "246292447922fcbb",
+        "z": "8ba5b00d69c6f447",
+        "g": "86d607ed8d206722",
         "name": "Trace",
         "rules": [
             {
@@ -15327,16 +11379,16 @@
         "y": 180,
         "wires": [
             [
-                "3d15c40d7d9c95f6"
+                "dab6d5b8acc929b6"
             ]
         ],
         "info": "Attaches a breadcrumb trace to the msg\r\nso the user can reconstruct which route has\r\nbeen traveled"
     },
     {
-        "id": "8db52fa86b32845f",
+        "id": "1ec47dcaecbc9934",
         "type": "link out",
-        "z": "45268219e4d1f409",
-        "g": "dbe25a81c3549f8b",
+        "z": "8ba5b00d69c6f447",
+        "g": "eacc42e8c2f36428",
         "name": "Return",
         "mode": "return",
         "links": [],
@@ -15345,10 +11397,10 @@
         "wires": []
     },
     {
-        "id": "62829e16a92f21a6",
+        "id": "57dd0a20ace29b6b",
         "type": "comment",
-        "z": "45268219e4d1f409",
-        "g": "dbe25a81c3549f8b",
+        "z": "8ba5b00d69c6f447",
+        "g": "eacc42e8c2f36428",
         "name": "End (readme)",
         "info": "Should return a solution_array of battery objects\n\n## battery object format\n`{{id: string|number, mode: string, power: number}} battery solution`\n- id is an arbitrary battery ID\n- mode is \"stop\", \"charge\", \"discharge\" for Marstek\n- power in Watts\n\n### example array\nreturn this type of solution_array via msg.solutions\n` \nlet solution_array = [];\nsolution_array.push({id:\"M1\", mode: \"charge\", power: 100}); // per battery\nreturn {solutions: solution_array};\n` ",
         "x": 130,
@@ -15356,10 +11408,10 @@
         "wires": []
     },
     {
-        "id": "732e7c368fd91726",
+        "id": "bdf742552095efcb",
         "type": "function",
-        "z": "45268219e4d1f409",
-        "g": "7880ef0bdff4a97b",
+        "z": "8ba5b00d69c6f447",
+        "g": "e72106615ec789d4",
         "name": "Max power solution",
         "func": "// Logger, usage: log(this, \"\");\nconst log = global.get('logger');\nlog(this, \"Discharge at **max. power**\");\n\n// INPUT\nlet batteries = msg.batteries;\nlet solution_array = [];\n\n// build solution\nmsg.batteries.forEach(battery => {\n    const calculatedPower = Number(battery.discharging_max);\n\n    solution_array.push({\n        id: battery.id,\n        mode: \"discharge\",\n        power: calculatedPower\n    });\n\n});\n\n// return solution\nmsg.solutions = solution_array;\nreturn msg;",
         "outputs": 1,
@@ -15372,15 +11424,15 @@
         "y": 360,
         "wires": [
             [
-                "61a4d662deab1f8e"
+                "a07d0579bf039375"
             ]
         ]
     },
     {
-        "id": "3dfb017412210c2d",
+        "id": "1c6ee7deb5930ade",
         "type": "link call",
-        "z": "45268219e4d1f409",
-        "g": "7880ef0bdff4a97b",
+        "z": "8ba5b00d69c6f447",
+        "g": "e72106615ec789d4",
         "name": "Call flow",
         "links": [],
         "linkType": "dynamic",
@@ -15389,16 +11441,16 @@
         "y": 400,
         "wires": [
             [
-                "1ee027a08b5fa2ca",
-                "f358858eef8a40ea"
+                "8016ca83d9ca33e9",
+                "601999b6eb8e6113"
             ]
         ]
     },
     {
-        "id": "2cf3625539d84467",
+        "id": "c484ab904b03e8f0",
         "type": "switch",
-        "z": "45268219e4d1f409",
-        "g": "7880ef0bdff4a97b",
+        "z": "8ba5b00d69c6f447",
+        "g": "e72106615ec789d4",
         "name": "Export at max power",
         "property": "grid_power_has_limit_export",
         "propertyType": "msg",
@@ -15417,18 +11469,18 @@
         "y": 380,
         "wires": [
             [
-                "732e7c368fd91726"
+                "bdf742552095efcb"
             ],
             [
-                "4cd4fdfca279a3ad"
+                "3bfede3f1b8890f9"
             ]
         ]
     },
     {
-        "id": "1ee027a08b5fa2ca",
+        "id": "8016ca83d9ca33e9",
         "type": "debug",
-        "z": "45268219e4d1f409",
-        "g": "7880ef0bdff4a97b",
+        "z": "8ba5b00d69c6f447",
+        "g": "e72106615ec789d4",
         "name": "Regulated",
         "active": true,
         "tosidebar": false,
@@ -15443,10 +11495,10 @@
         "wires": []
     },
     {
-        "id": "a878122484b8ade7",
+        "id": "e1e571717b44f101",
         "type": "debug",
-        "z": "45268219e4d1f409",
-        "g": "7880ef0bdff4a97b",
+        "z": "8ba5b00d69c6f447",
+        "g": "e72106615ec789d4",
         "name": "Maximum",
         "active": true,
         "tosidebar": false,
@@ -15461,10 +11513,10 @@
         "wires": []
     },
     {
-        "id": "4cd4fdfca279a3ad",
+        "id": "3bfede3f1b8890f9",
         "type": "function",
-        "z": "45268219e4d1f409",
-        "g": "7880ef0bdff4a97b",
+        "z": "8ba5b00d69c6f447",
+        "g": "e72106615ec789d4",
         "name": "Regulated power",
         "func": "// Logger, usage: log(this, \"\");\nconst log = global.get('logger');\n\n// Which sub-strategy to use\nmsg.target = \"Self-consumption\";\n\n// Grid power limit\nconst targetGridPower = parseInt(msg.grid_power_limit_export);\n\n// Set target grid consumption for the PID controller\nmsg.house_target_grid_consumption_in_w = -targetGridPower; // negative, we are exporting to grid.\n// tell PID to avoid charge solutions during Selling.\nRED.util.setMessageProperty(msg,\"advanced_settings.charge_disabled\",true,true);\n\n// Finally\nlog(this, `**Regulated** discharging. Target grid power: ${Math.floor(targetGridPower)} W`);\nreturn msg;",
         "outputs": 1,
@@ -15477,15 +11529,15 @@
         "y": 400,
         "wires": [
             [
-                "3dfb017412210c2d"
+                "1c6ee7deb5930ade"
             ]
         ]
     },
     {
-        "id": "61a4d662deab1f8e",
+        "id": "a07d0579bf039375",
         "type": "change",
-        "z": "45268219e4d1f409",
-        "g": "7880ef0bdff4a97b",
+        "z": "8ba5b00d69c6f447",
+        "g": "e72106615ec789d4",
         "name": "Continue",
         "rules": [
             {
@@ -15505,16 +11557,16 @@
         "y": 360,
         "wires": [
             [
-                "a878122484b8ade7",
-                "f358858eef8a40ea"
+                "e1e571717b44f101",
+                "601999b6eb8e6113"
             ]
         ]
     },
     {
-        "id": "52067ef98127cc7f",
+        "id": "4c11202ace08f27c",
         "type": "function",
-        "z": "45268219e4d1f409",
-        "g": "1f2beb406508348d",
+        "z": "8ba5b00d69c6f447",
+        "g": "c1a0dc6672015b4e",
         "name": "Min/max",
         "func": "\n// Lower bound\nlet output = msg.sell.threshold_energy | 0; // kWh\noutput = Math.max(output, 0);\n\n// Upper bound\nlet max_reserve = 0; // kWh\nmsg.batteries.forEach(battery => {\n    max_reserve += (Number(battery.energy_max*battery.soc_max) - Number(battery.energy_max*battery.soc_min))/100; // kWh\n});\noutput = Math.min(output, max_reserve);\n\nnode.status({fill:\"blue\",shape:\"dot\",text:`${output}`});\n\n// Output\nmsg.payload = output;\n\nreturn msg;",
         "outputs": 1,
@@ -15527,15 +11579,15 @@
         "y": 200,
         "wires": [
             [
-                "f66801007c26edf9"
+                "f749f46ef2094218"
             ]
         ]
     },
     {
-        "id": "f66801007c26edf9",
+        "id": "f749f46ef2094218",
         "type": "api-call-service",
-        "z": "45268219e4d1f409",
-        "g": "1f2beb406508348d",
+        "z": "8ba5b00d69c6f447",
+        "g": "c1a0dc6672015b4e",
         "name": "Set desired energy reserve",
         "server": "176d29a.6f648d6",
         "version": 7,
@@ -15564,10 +11616,10 @@
         ]
     },
     {
-        "id": "d0a92a6efa9b40a4",
+        "id": "7a16b8de0fa74077",
         "type": "rbe",
-        "z": "45268219e4d1f409",
-        "g": "1f2beb406508348d",
+        "z": "8ba5b00d69c6f447",
+        "g": "c1a0dc6672015b4e",
         "name": "Desired energy changed",
         "func": "rbe",
         "gap": "",
@@ -15580,15 +11632,15 @@
         "y": 200,
         "wires": [
             [
-                "52067ef98127cc7f"
+                "4c11202ace08f27c"
             ]
         ]
     },
     {
-        "id": "bb7a0784d0b0a22a",
+        "id": "3ecade755b21b53d",
         "type": "api-current-state",
-        "z": "45268219e4d1f409",
-        "g": "a1f61dc615ba5d8f",
+        "z": "8ba5b00d69c6f447",
+        "g": "733019b51f77eb7a",
         "name": "Goal",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -15631,15 +11683,15 @@
         "y": 180,
         "wires": [
             [
-                "e6908f227e388e39"
+                "6548cfcf77f80efe"
             ]
         ]
     },
     {
-        "id": "e6908f227e388e39",
+        "id": "6548cfcf77f80efe",
         "type": "switch",
-        "z": "45268219e4d1f409",
-        "g": "a1f61dc615ba5d8f",
+        "z": "8ba5b00d69c6f447",
+        "g": "733019b51f77eb7a",
         "name": "Sell until",
         "property": "sell.goal",
         "propertyType": "msg",
@@ -15670,24 +11722,24 @@
         "y": 180,
         "wires": [
             [
-                "65e116498f8e91d3"
+                "2687dba26a756923"
             ],
             [
-                "1ee914269e547271"
+                "6f84c1c2f39b51b5"
             ],
             [
-                "5023e4d6837ee277"
+                "8f65bdecdb4a4288"
             ],
             [
-                "6f306c9f5741cf4e"
+                "e04893db342263e4"
             ]
         ]
     },
     {
-        "id": "6f306c9f5741cf4e",
+        "id": "e04893db342263e4",
         "type": "function",
-        "z": "45268219e4d1f409",
-        "g": "a1f61dc615ba5d8f",
+        "z": "8ba5b00d69c6f447",
+        "g": "733019b51f77eb7a",
         "name": "Unknown -> Full stop",
         "func": "const log = global.get(\"logger\");\n\n// Unkown export goal\nlog(this, `**${msg.sell.goal}**; Sell goal not recognized. Fallback to **Full Stop**`,\"warn\");\n\n// Full stop\nmsg.target = \"Full stop\";\n\nreturn msg;",
         "outputs": 1,
@@ -15700,15 +11752,15 @@
         "y": 240,
         "wires": [
             [
-                "c03ff041a7142ecc"
+                "b5cd36a90cfbcefc"
             ]
         ]
     },
     {
-        "id": "3d15c40d7d9c95f6",
+        "id": "dab6d5b8acc929b6",
         "type": "function",
-        "z": "45268219e4d1f409",
-        "g": "a1f61dc615ba5d8f",
+        "z": "8ba5b00d69c6f447",
+        "g": "733019b51f77eb7a",
         "name": "Init",
         "func": "msg.sell = {};\n\nreturn msg;",
         "outputs": 1,
@@ -15721,15 +11773,15 @@
         "y": 180,
         "wires": [
             [
-                "bb7a0784d0b0a22a"
+                "3ecade755b21b53d"
             ]
         ]
     },
     {
-        "id": "c03ff041a7142ecc",
+        "id": "b5cd36a90cfbcefc",
         "type": "link call",
-        "z": "45268219e4d1f409",
-        "g": "a1f61dc615ba5d8f",
+        "z": "8ba5b00d69c6f447",
+        "g": "733019b51f77eb7a",
         "name": "Call flow",
         "links": [],
         "linkType": "dynamic",
@@ -15738,15 +11790,15 @@
         "y": 240,
         "wires": [
             [
-                "af6f8e11181935f2"
+                "10140a54c1c40f58"
             ]
         ]
     },
     {
-        "id": "5023e4d6837ee277",
+        "id": "8f65bdecdb4a4288",
         "type": "api-current-state",
-        "z": "45268219e4d1f409",
-        "g": "a1f61dc615ba5d8f",
+        "z": "8ba5b00d69c6f447",
+        "g": "733019b51f77eb7a",
         "name": "Energy reserve low",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -15789,38 +11841,38 @@
         "y": 200,
         "wires": [
             [
-                "382fbf05d750f570"
+                "6e5acf1cfdd583e2"
             ]
         ]
     },
     {
-        "id": "a3f14b65313acd42",
+        "id": "5ce8150b15e8bbbc",
         "type": "link in",
-        "z": "45268219e4d1f409",
-        "g": "dbe25a81c3549f8b",
+        "z": "8ba5b00d69c6f447",
+        "g": "eacc42e8c2f36428",
         "name": "link to End",
         "links": [
-            "af6f8e11181935f2",
-            "a7f5468f86d710bf",
-            "f358858eef8a40ea"
+            "10140a54c1c40f58",
+            "5e1748777184ab13",
+            "601999b6eb8e6113"
         ],
         "x": 75,
         "y": 580,
         "wires": [
             [
-                "8db52fa86b32845f"
+                "1ec47dcaecbc9934"
             ]
         ]
     },
     {
-        "id": "af6f8e11181935f2",
+        "id": "10140a54c1c40f58",
         "type": "link out",
-        "z": "45268219e4d1f409",
-        "g": "a1f61dc615ba5d8f",
+        "z": "8ba5b00d69c6f447",
+        "g": "733019b51f77eb7a",
         "name": "go to End",
         "mode": "link",
         "links": [
-            "a3f14b65313acd42"
+            "5ce8150b15e8bbbc"
         ],
         "x": 1140,
         "y": 240,
@@ -15828,10 +11880,10 @@
         "l": true
     },
     {
-        "id": "1ee914269e547271",
+        "id": "6f84c1c2f39b51b5",
         "type": "api-current-state",
-        "z": "45268219e4d1f409",
-        "g": "a1f61dc615ba5d8f",
+        "z": "8ba5b00d69c6f447",
+        "g": "733019b51f77eb7a",
         "name": "SoC low",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -15874,15 +11926,15 @@
         "y": 160,
         "wires": [
             [
-                "3070b4f04d1ed836"
+                "35c180cc2e111f20"
             ]
         ]
     },
     {
-        "id": "382fbf05d750f570",
+        "id": "6e5acf1cfdd583e2",
         "type": "function",
-        "z": "45268219e4d1f409",
-        "g": "a1f61dc615ba5d8f",
+        "z": "8ba5b00d69c6f447",
+        "g": "733019b51f77eb7a",
         "name": "Check if low",
         "func": "// 1. Get the custom logger from global context\nconst log = global.get(\"logger\");\nlog(this,`Sell until: ${msg.sell.goal}`);\n\n// 2. Extract energy level from msg (default to 0 if property is missing)\nconst energy_remaining = Number(RED.util.getMessageProperty(msg, \"batteries_available_energy\")) || 0;\nvar energy_threshold = Number(RED.util.getMessageProperty(msg,\"sell.threshold_energy\"));\nif (energy_threshold === undefined || energy_threshold < 0){\n    log(this,`Desired energy reserve not set correctly '${energy_threshold}' kWh`,\"warn\");\n    energy_threshold = 0;\n}\n\n// 3. Logic: Determine if energy level is at or below zero\nif (energy_remaining <= energy_threshold) {\n    msg.sell.threshold_reached = true;\n    \n    // User friendly feedback via the custom logger\n    log(this, `[STOP] Energy reserve at ${energy_remaining.toFixed(1)} / ${energy_threshold.toFixed(1)} kWh`, 'info');\n} else {\n    msg.sell.threshold_reached = false;\n    \n    // User friendly feedback via the custom logger\n    log(this, `[OK] Energy reserve at ${energy_remaining.toFixed(1)} / ${energy_threshold.toFixed(1)} kWh.`, 'info');\n}\n\n// 4. Update node status for visual feedback in the editor\nnode.status({ \n    fill: msg.sell.threshold_reached ? \"red\" : \"green\", \n    shape: \"dot\", \n    text: `Threshold reached: ${msg.sell.threshold_reached}` \n});\n\nreturn msg;",
         "outputs": 1,
@@ -15895,16 +11947,16 @@
         "y": 200,
         "wires": [
             [
-                "9d0bdc7bd80b7a2d",
-                "d0a92a6efa9b40a4"
+                "316260d4707381d4",
+                "7a16b8de0fa74077"
             ]
         ]
     },
     {
-        "id": "3070b4f04d1ed836",
+        "id": "35c180cc2e111f20",
         "type": "function",
-        "z": "45268219e4d1f409",
-        "g": "a1f61dc615ba5d8f",
+        "z": "8ba5b00d69c6f447",
+        "g": "733019b51f77eb7a",
         "name": "Check if low",
         "func": "// 1. Get the custom logger from global context\nconst log = global.get(\"logger\");\nlog(this, `Sell until: ${msg.sell.goal}`);\n\n// 2. Extract average SoC and desired SoC level\nlet batteries = msg.batteries;\nlet soc_avg = 0;\nlet count = 0; // could use msg.battery_count\nbatteries.forEach(battery => {\n    soc_avg += battery.soc;\n    count++;\n});\n// 2a.  Current avg. SoC\nsoc_avg = Math.round(soc_avg / count * 100) / 100;\n// 2b.  Sell until SoC (11% as fallback)\nvar soc_threshold = Number(RED.util.getMessageProperty(msg,\"sell.threshold_soc\"));\nif (soc_threshold === undefined || soc_threshold < 11){\n    log(this, `Desired SoC not set correctly '${soc_threshold}' %. I've set it to 11%.`,\"warn\");\n    soc_threshold = 11;\n}\n\n// 3. Logic: Determine if SoC level is at or below desired level\nif (soc_avg <= msg.payload) {\n    msg.sell.threshold_reached = true;\n\n    // User friendly feedback via the custom logger\n    log(this, `[STOP] Average SoC at ${soc_avg.toFixed(1)}/${soc_threshold.toFixed(1)} %.`, 'info');\n} else {\n    msg.sell.threshold_reached = false;\n\n    // User friendly feedback via the custom logger\n    log(this, `[OK] Average SoC at ${soc_avg.toFixed(1)}/${soc_threshold.toFixed(1)} %.`, 'info');\n}\n\n// 4. Update node status for visual feedback in the editor\nnode.status({\n    fill: msg.sell.threshold_reached ? \"red\" : \"green\",\n    shape: \"dot\",\n    text: `Threshold reached: ${msg.sell.threshold_reached}`\n});\n\nreturn msg;",
         "outputs": 1,
@@ -15917,15 +11969,15 @@
         "y": 160,
         "wires": [
             [
-                "9d0bdc7bd80b7a2d"
+                "316260d4707381d4"
             ]
         ]
     },
     {
-        "id": "65e116498f8e91d3",
+        "id": "2687dba26a756923",
         "type": "change",
-        "z": "45268219e4d1f409",
-        "g": "a1f61dc615ba5d8f",
+        "z": "8ba5b00d69c6f447",
+        "g": "733019b51f77eb7a",
         "name": "Batteries are empty",
         "rules": [
             {
@@ -15945,15 +11997,15 @@
         "y": 120,
         "wires": [
             [
-                "52c517eb55b55519"
+                "ee81b51972aa3e07"
             ]
         ]
     },
     {
-        "id": "52c517eb55b55519",
+        "id": "ee81b51972aa3e07",
         "type": "function",
-        "z": "45268219e4d1f409",
-        "g": "a1f61dc615ba5d8f",
+        "z": "8ba5b00d69c6f447",
+        "g": "733019b51f77eb7a",
         "name": "Check if empty",
         "func": "// 1. Get the custom logger from global context\nconst log = global.get(\"logger\");\nlog(this,`Sell until: ${msg.sell.goal}`);\n\n// 2. Extract energy level from msg (default to 0 if property is missing)\nconst energy_remaining = Number(RED.util.getMessageProperty(msg, \"batteries_available_energy\")) || 0;\n\n// 3. Logic: Determine if energy level is at or below zero\nif (energy_remaining <= 0) {\n    msg.sell.threshold_reached = true;\n    \n    // User friendly feedback via the custom logger\n    log(this, `[STOP] All batteries are empty or at SoC_min_ (${energy_remaining} kWh).`, 'info');\n} else {\n    msg.sell.threshold_reached = false;\n    \n    // User friendly feedback via the custom logger\n    log(this, `[OK] Battery level ${energy_remaining.toFixed(2)} kWh above 0 kWh.`, 'info');\n}\n\n// 4. Update node status for visual feedback in the editor\nnode.status({ \n    fill: msg.sell.threshold_reached ? \"red\" : \"green\", \n    shape: \"dot\", \n    text: `Threshold reached: ${msg.sell.threshold_reached}` \n});\n\nreturn msg;",
         "outputs": 1,
@@ -15966,15 +12018,15 @@
         "y": 120,
         "wires": [
             [
-                "9d0bdc7bd80b7a2d"
+                "316260d4707381d4"
             ]
         ]
     },
     {
-        "id": "295e494c53b201d0",
+        "id": "13900436861254c3",
         "type": "switch",
-        "z": "45268219e4d1f409",
-        "g": "a1f61dc615ba5d8f",
+        "z": "8ba5b00d69c6f447",
+        "g": "733019b51f77eb7a",
         "name": "Until reached",
         "property": "sell.threshold_reached",
         "propertyType": "msg",
@@ -15993,18 +12045,18 @@
         "y": 160,
         "wires": [
             [
-                "ec4416c541f0297e"
+                "f5bd674e556d61fe"
             ],
             [
-                "3b7e225dc182bb5c"
+                "3d7a88cb39de079b"
             ]
         ]
     },
     {
-        "id": "ec4416c541f0297e",
+        "id": "f5bd674e556d61fe",
         "type": "function",
-        "z": "45268219e4d1f409",
-        "g": "a1f61dc615ba5d8f",
+        "z": "8ba5b00d69c6f447",
+        "g": "733019b51f77eb7a",
         "name": "Yes -> Full stop",
         "func": "\nmsg.target = \"Full stop\";\nreturn msg;",
         "outputs": 1,
@@ -16017,15 +12069,15 @@
         "y": 120,
         "wires": [
             [
-                "19e2deec0b59aa3e"
+                "3d7f072c3ab91050"
             ]
         ]
     },
     {
-        "id": "19e2deec0b59aa3e",
+        "id": "3d7f072c3ab91050",
         "type": "link call",
-        "z": "45268219e4d1f409",
-        "g": "a1f61dc615ba5d8f",
+        "z": "8ba5b00d69c6f447",
+        "g": "733019b51f77eb7a",
         "name": "Call flow",
         "links": [],
         "linkType": "dynamic",
@@ -16034,19 +12086,19 @@
         "y": 120,
         "wires": [
             [
-                "a7f5468f86d710bf"
+                "5e1748777184ab13"
             ]
         ]
     },
     {
-        "id": "a7f5468f86d710bf",
+        "id": "5e1748777184ab13",
         "type": "link out",
-        "z": "45268219e4d1f409",
-        "g": "a1f61dc615ba5d8f",
+        "z": "8ba5b00d69c6f447",
+        "g": "733019b51f77eb7a",
         "name": "go to End",
         "mode": "link",
         "links": [
-            "a3f14b65313acd42"
+            "5ce8150b15e8bbbc"
         ],
         "x": 1820,
         "y": 120,
@@ -16054,10 +12106,10 @@
         "l": true
     },
     {
-        "id": "9d0bdc7bd80b7a2d",
+        "id": "316260d4707381d4",
         "type": "function",
-        "z": "45268219e4d1f409",
-        "g": "a1f61dc615ba5d8f",
+        "z": "8ba5b00d69c6f447",
+        "g": "733019b51f77eb7a",
         "name": "Decided",
         "func": "const log = global.get(\"logger\");\n\nif(msg.sell.threshold_reached){\n    log(this,`Stop discharging, Sell until ${msg.sell.goal} reached.`);\n} else {\n    log(this,`Continue discharging.`);\n}\n\nreturn msg;",
         "outputs": 1,
@@ -16070,19 +12122,19 @@
         "y": 160,
         "wires": [
             [
-                "295e494c53b201d0"
+                "13900436861254c3"
             ]
         ]
     },
     {
-        "id": "f358858eef8a40ea",
+        "id": "601999b6eb8e6113",
         "type": "link out",
-        "z": "45268219e4d1f409",
-        "g": "7880ef0bdff4a97b",
+        "z": "8ba5b00d69c6f447",
+        "g": "e72106615ec789d4",
         "name": "go to End",
         "mode": "link",
         "links": [
-            "a3f14b65313acd42"
+            "5ce8150b15e8bbbc"
         ],
         "x": 960,
         "y": 460,
@@ -16090,10 +12142,10 @@
         "l": true
     },
     {
-        "id": "5be717f63dea6b25",
+        "id": "529e71f22646a27b",
         "type": "catch",
-        "z": "45268219e4d1f409",
-        "g": "e95797c2440b0faa",
+        "z": "8ba5b00d69c6f447",
+        "g": "8a2cca347fcb8d09",
         "name": "",
         "scope": null,
         "uncaught": false,
@@ -16101,16 +12153,16 @@
         "y": 420,
         "wires": [
             [
-                "1eb7fb4ce8ab4110"
+                "10d4a7728ee7c964"
             ]
         ],
         "l": false
     },
     {
-        "id": "1eb7fb4ce8ab4110",
+        "id": "10d4a7728ee7c964",
         "type": "function",
-        "z": "45268219e4d1f409",
-        "g": "e95797c2440b0faa",
+        "z": "8ba5b00d69c6f447",
+        "g": "8a2cca347fcb8d09",
         "name": "Unhandled Exception",
         "func": "const handle = global.get('unhandledException');\n\nhandle(this);\n\nreturn msg;",
         "outputs": 1,
@@ -16123,16 +12175,16 @@
         "y": 420,
         "wires": [
             [
-                "dd2e5bf97c7876cd"
+                "09cff1fc2fd9ee36"
             ]
         ],
         "l": false
     },
     {
-        "id": "dd2e5bf97c7876cd",
+        "id": "09cff1fc2fd9ee36",
         "type": "link out",
-        "z": "45268219e4d1f409",
-        "g": "e95797c2440b0faa",
+        "z": "8ba5b00d69c6f447",
+        "g": "8a2cca347fcb8d09",
         "name": "link out 2",
         "mode": "return",
         "links": [],
@@ -16141,25 +12193,25 @@
         "wires": []
     },
     {
-        "id": "31775b862ba37b46",
+        "id": "1dceb39476cd10f2",
         "type": "link in",
-        "z": "9e39224fc3ece381",
-        "g": "f638c541e43f0f69",
+        "z": "c09e6bbf3a0800ef",
+        "g": "abcad92e2e6ee7b8",
         "name": "Timed",
         "links": [],
         "x": 110,
         "y": 160,
         "wires": [
             [
-                "722fe0c2ad88122e"
+                "a1eb9a3022f44c9c"
             ]
         ],
         "l": true
     },
     {
-        "id": "d951b13985b41395",
+        "id": "10eba89bb9c6d411",
         "type": "comment",
-        "z": "9e39224fc3ece381",
+        "z": "c09e6bbf3a0800ef",
         "name": "Home Battery Strategy",
         "info": "The `Home Battery Start` flow will call this strategy flow\nby matching the strategy name with the Link In name.\n\nConfigure the Link In node in the Start group.\n\nDon't modify other parts of the Start and End groups.\nThey handle the calling and returning for you.",
         "x": 130,
@@ -16167,10 +12219,10 @@
         "wires": []
     },
     {
-        "id": "21e41b1aa944c3d4",
+        "id": "79e577f3b7aac2ef",
         "type": "comment",
-        "z": "9e39224fc3ece381",
-        "g": "f638c541e43f0f69",
+        "z": "c09e6bbf3a0800ef",
+        "g": "abcad92e2e6ee7b8",
         "name": "Start (readme)",
         "info": "# Setting up your battery strategy flow\n\n## Setup\nName the `Link In node` in this start group exactly after the <select> option configured in your\nselect_input.house_battery_strategy\n\nconfigure select options in:\ninput_select_house_battery_control.yaml\n\n### example\n`house_battery_strategy:\n  name: House Battery Strategy\n  options:\n    - AcmE example`\n\nThe above creates a select option, allowing user to select 'AcmE example'\n\nWhen selected, battery control will search for a flow containing a Link In node\ncalled 'AcmE example' (case sensitive).",
         "x": 120,
@@ -16178,10 +12230,10 @@
         "wires": []
     },
     {
-        "id": "ce6d45b3bce03cef",
+        "id": "9d6516c7832ce16d",
         "type": "link out",
-        "z": "9e39224fc3ece381",
-        "g": "f63e605c588a8b4a",
+        "z": "c09e6bbf3a0800ef",
+        "g": "5f88f837af19f280",
         "name": "Return",
         "mode": "return",
         "links": [],
@@ -16190,10 +12242,10 @@
         "wires": []
     },
     {
-        "id": "d39fd4ac49ce6de3",
+        "id": "af8877f380061516",
         "type": "comment",
-        "z": "9e39224fc3ece381",
-        "g": "f63e605c588a8b4a",
+        "z": "c09e6bbf3a0800ef",
+        "g": "5f88f837af19f280",
         "name": "End (readme)",
         "info": "Should return a solution_array of battery objects\n\n## battery object format\n`{{id: string|number, mode: string, power: number}} battery solution`\n- id is an arbitrary battery ID\n- mode is \"stop\", \"charge\", \"discharge\" for Marstek\n- power in Watts\n\n### example array\nreturn this type of solution_array via msg.solutions\n` \nlet solution_array = [];\nsolution_array.push({id:\"M1\", mode: \"charge\", power: 100}); // per battery\nreturn {solutions: solution_array};\n` ",
         "x": 1310,
@@ -16201,10 +12253,10 @@
         "wires": []
     },
     {
-        "id": "5dba707199b28c91",
+        "id": "560b4a9a1e8b91b9",
         "type": "api-current-state",
-        "z": "9e39224fc3ece381",
-        "g": "76cf7d7bb3702120",
+        "z": "c09e6bbf3a0800ef",
+        "g": "a5176edf2bc15719",
         "name": "Period A start",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -16247,15 +12299,15 @@
         "y": 120,
         "wires": [
             [
-                "ee9bc4527bad8a05"
+                "e31d349eb20308ef"
             ]
         ]
     },
     {
-        "id": "ee9bc4527bad8a05",
+        "id": "e31d349eb20308ef",
         "type": "api-current-state",
-        "z": "9e39224fc3ece381",
-        "g": "76cf7d7bb3702120",
+        "z": "c09e6bbf3a0800ef",
+        "g": "a5176edf2bc15719",
         "name": "Period A end",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -16298,15 +12350,15 @@
         "y": 120,
         "wires": [
             [
-                "5f99c3b39c65f674"
+                "17827d992ed7afe4"
             ]
         ]
     },
     {
-        "id": "50623a53fc482b6d",
+        "id": "8f0d728b0caa0f19",
         "type": "api-current-state",
-        "z": "9e39224fc3ece381",
-        "g": "eb9d3a40ae2013dd",
+        "z": "c09e6bbf3a0800ef",
+        "g": "8e537d3294b55627",
         "name": "Period B start",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -16349,15 +12401,15 @@
         "y": 220,
         "wires": [
             [
-                "4f863af7dfb788b7"
+                "1695c2c95a6e9097"
             ]
         ]
     },
     {
-        "id": "4f863af7dfb788b7",
+        "id": "1695c2c95a6e9097",
         "type": "api-current-state",
-        "z": "9e39224fc3ece381",
-        "g": "eb9d3a40ae2013dd",
+        "z": "c09e6bbf3a0800ef",
+        "g": "8e537d3294b55627",
         "name": "Period B end",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -16400,15 +12452,15 @@
         "y": 220,
         "wires": [
             [
-                "f62cf74381b252b5"
+                "b0172dad79c9d9d9"
             ]
         ]
     },
     {
-        "id": "5f99c3b39c65f674",
+        "id": "17827d992ed7afe4",
         "type": "api-current-state",
-        "z": "9e39224fc3ece381",
-        "g": "76cf7d7bb3702120",
+        "z": "c09e6bbf3a0800ef",
+        "g": "a5176edf2bc15719",
         "name": "Strat during A",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -16451,15 +12503,15 @@
         "y": 120,
         "wires": [
             [
-                "ac0e4f19465cfc6f"
+                "23f9975e55c16d6a"
             ]
         ]
     },
     {
-        "id": "f62cf74381b252b5",
+        "id": "b0172dad79c9d9d9",
         "type": "api-current-state",
-        "z": "9e39224fc3ece381",
-        "g": "eb9d3a40ae2013dd",
+        "z": "c09e6bbf3a0800ef",
+        "g": "8e537d3294b55627",
         "name": "Strat during B",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -16502,15 +12554,15 @@
         "y": 220,
         "wires": [
             [
-                "0af565b205e2a70a"
+                "72debbc7da5632d8"
             ]
         ]
     },
     {
-        "id": "ac0e4f19465cfc6f",
+        "id": "23f9975e55c16d6a",
         "type": "api-current-state",
-        "z": "9e39224fc3ece381",
-        "g": "eb9d3a40ae2013dd",
+        "z": "c09e6bbf3a0800ef",
+        "g": "8e537d3294b55627",
         "name": "Has period B",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -16553,14 +12605,14 @@
         "y": 220,
         "wires": [
             [
-                "50623a53fc482b6d"
+                "8f0d728b0caa0f19"
             ]
         ]
     },
     {
-        "id": "93338c1baad9b2d4",
+        "id": "a488535aebcd29cb",
         "type": "inject",
-        "z": "9e39224fc3ece381",
+        "z": "c09e6bbf3a0800ef",
         "name": "Test",
         "props": [
             {
@@ -16582,15 +12634,15 @@
         "y": 40,
         "wires": [
             [
-                "1c93b6485d540087"
+                "d2de59203f47d4c6"
             ]
         ]
     },
     {
-        "id": "6ebc6dcd578d07a2",
+        "id": "76e9feedad68bca7",
         "type": "change",
-        "z": "9e39224fc3ece381",
-        "g": "bdf4f6805cf509e0",
+        "z": "c09e6bbf3a0800ef",
+        "g": "585d1a52b35dfa92",
         "name": "set Strat 0",
         "rules": [
             {
@@ -16610,15 +12662,15 @@
         "y": 460,
         "wires": [
             [
-                "5d43b1088113a139"
+                "304a41111aa90bd6"
             ]
         ]
     },
     {
-        "id": "b8fda06d12873ad8",
+        "id": "a4d0333032e37b8a",
         "type": "change",
-        "z": "9e39224fc3ece381",
-        "g": "bdf4f6805cf509e0",
+        "z": "c09e6bbf3a0800ef",
+        "g": "585d1a52b35dfa92",
         "name": "set Strat A",
         "rules": [
             {
@@ -16638,16 +12690,16 @@
         "y": 420,
         "wires": [
             [
-                "5dbf89cce4010125",
-                "8861cb91879fcbd7"
+                "8dd679613f4a188a",
+                "f1e61865b1bd941b"
             ]
         ]
     },
     {
-        "id": "5d43b1088113a139",
+        "id": "304a41111aa90bd6",
         "type": "switch",
-        "z": "9e39224fc3ece381",
-        "g": "bdf4f6805cf509e0",
+        "z": "c09e6bbf3a0800ef",
+        "g": "585d1a52b35dfa92",
         "name": "has period B",
         "property": "house_battery_strategy_timed_has_period_b",
         "propertyType": "msg",
@@ -16670,19 +12722,19 @@
         "y": 500,
         "wires": [
             [
-                "5dbf89cce4010125",
-                "49cecfb0dc7b9b56"
+                "8dd679613f4a188a",
+                "cf31b793475b2611"
             ],
             [
-                "f3a9a2ab8e3ab017"
+                "1e5aedafc9c49701"
             ]
         ]
     },
     {
-        "id": "f30fcd3659ee7c20",
+        "id": "b5d09f0f33171291",
         "type": "function",
-        "z": "9e39224fc3ece381",
-        "g": "bdf4f6805cf509e0",
+        "z": "c09e6bbf3a0800ef",
+        "g": "585d1a52b35dfa92",
         "name": "config A",
         "func": "msg.__config = {\n    startTime: RED.util.getMessageProperty(msg,'house_battery_strategy_timed_period_a1'),\n    endTime: RED.util.getMessageProperty(msg,'house_battery_strategy_timed_period_a2'),\n    startOffset: 0,\n    endOffset: 0\n}\n  \nreturn msg;",
         "outputs": 1,
@@ -16695,15 +12747,15 @@
         "y": 440,
         "wires": [
             [
-                "21f66951028bc3e3"
+                "148b533a6ee8d566"
             ]
         ]
     },
     {
-        "id": "21f66951028bc3e3",
+        "id": "148b533a6ee8d566",
         "type": "time-range-switch",
-        "z": "9e39224fc3ece381",
-        "g": "bdf4f6805cf509e0",
+        "z": "c09e6bbf3a0800ef",
+        "g": "585d1a52b35dfa92",
         "name": "Period A",
         "lat": "",
         "lon": "",
@@ -16715,18 +12767,18 @@
         "y": 440,
         "wires": [
             [
-                "b8fda06d12873ad8"
+                "a4d0333032e37b8a"
             ],
             [
-                "6ebc6dcd578d07a2"
+                "76e9feedad68bca7"
             ]
         ]
     },
     {
-        "id": "f3a9a2ab8e3ab017",
+        "id": "1e5aedafc9c49701",
         "type": "function",
-        "z": "9e39224fc3ece381",
-        "g": "bdf4f6805cf509e0",
+        "z": "c09e6bbf3a0800ef",
+        "g": "585d1a52b35dfa92",
         "name": "config B",
         "func": "msg.__config = {\n    startTime: RED.util.getMessageProperty(msg,'house_battery_strategy_timed_period_b1'),\n    endTime: RED.util.getMessageProperty(msg,'house_battery_strategy_timed_period_b2'),\n    startOffset: 0,\n    endOffset: 0\n}\n  \nreturn msg;",
         "outputs": 1,
@@ -16739,15 +12791,15 @@
         "y": 580,
         "wires": [
             [
-                "ac9f52c876b781d1"
+                "f304ab42d3e05e83"
             ]
         ]
     },
     {
-        "id": "ac9f52c876b781d1",
+        "id": "f304ab42d3e05e83",
         "type": "time-range-switch",
-        "z": "9e39224fc3ece381",
-        "g": "bdf4f6805cf509e0",
+        "z": "c09e6bbf3a0800ef",
+        "g": "585d1a52b35dfa92",
         "name": "Period B",
         "lat": "",
         "lon": "",
@@ -16759,18 +12811,18 @@
         "y": 580,
         "wires": [
             [
-                "8f8a2d85bcf501bf"
+                "6dfb0f680ff0cfe1"
             ],
             [
-                "f186013b043694b7"
+                "cb3cbbdc3470774d"
             ]
         ]
     },
     {
-        "id": "8f8a2d85bcf501bf",
+        "id": "6dfb0f680ff0cfe1",
         "type": "change",
-        "z": "9e39224fc3ece381",
-        "g": "bdf4f6805cf509e0",
+        "z": "c09e6bbf3a0800ef",
+        "g": "585d1a52b35dfa92",
         "name": "set Strat B",
         "rules": [
             {
@@ -16790,16 +12842,16 @@
         "y": 560,
         "wires": [
             [
-                "5dbf89cce4010125",
-                "66536c91bfd8a1f5"
+                "8dd679613f4a188a",
+                "8525462b2dad264e"
             ]
         ]
     },
     {
-        "id": "f186013b043694b7",
+        "id": "cb3cbbdc3470774d",
         "type": "change",
-        "z": "9e39224fc3ece381",
-        "g": "bdf4f6805cf509e0",
+        "z": "c09e6bbf3a0800ef",
+        "g": "585d1a52b35dfa92",
         "name": "set Strat 0",
         "rules": [
             {
@@ -16819,15 +12871,15 @@
         "y": 600,
         "wires": [
             [
-                "c3fd307b8271989b"
+                "05d201d74c13fab1"
             ]
         ]
     },
     {
-        "id": "1c93b6485d540087",
+        "id": "d2de59203f47d4c6",
         "type": "api-current-state",
-        "z": "9e39224fc3ece381",
-        "g": "faa98cae0df8f0ad",
+        "z": "c09e6bbf3a0800ef",
+        "g": "376da246fd8c5004",
         "name": "Default Strat",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -16870,15 +12922,15 @@
         "y": 120,
         "wires": [
             [
-                "5dba707199b28c91"
+                "560b4a9a1e8b91b9"
             ]
         ]
     },
     {
-        "id": "d814459ac074e134",
+        "id": "e9bd13a3fe069246",
         "type": "link call",
-        "z": "9e39224fc3ece381",
-        "g": "d19e5ec6b8c9a4d5",
+        "z": "c09e6bbf3a0800ef",
+        "g": "5b8e1b80e73b4fc8",
         "name": "Sub strategy",
         "links": [],
         "linkType": "dynamic",
@@ -16887,15 +12939,15 @@
         "y": 520,
         "wires": [
             [
-                "ce6d45b3bce03cef"
+                "9d6516c7832ce16d"
             ]
         ]
     },
     {
-        "id": "5dbf89cce4010125",
+        "id": "8dd679613f4a188a",
         "type": "change",
-        "z": "9e39224fc3ece381",
-        "g": "bdf4f6805cf509e0",
+        "z": "c09e6bbf3a0800ef",
+        "g": "585d1a52b35dfa92",
         "name": "Select flow",
         "rules": [
             {
@@ -16915,16 +12967,16 @@
         "y": 520,
         "wires": [
             [
-                "d814459ac074e134",
-                "88c9e4aef0a3943e"
+                "e9bd13a3fe069246",
+                "89cab6d8692ea12d"
             ]
         ]
     },
     {
-        "id": "8861cb91879fcbd7",
+        "id": "f1e61865b1bd941b",
         "type": "debug",
-        "z": "9e39224fc3ece381",
-        "g": "bdf4f6805cf509e0",
+        "z": "c09e6bbf3a0800ef",
+        "g": "585d1a52b35dfa92",
         "name": "A",
         "active": true,
         "tosidebar": false,
@@ -16939,10 +12991,10 @@
         "wires": []
     },
     {
-        "id": "49cecfb0dc7b9b56",
+        "id": "cf31b793475b2611",
         "type": "debug",
-        "z": "9e39224fc3ece381",
-        "g": "bdf4f6805cf509e0",
+        "z": "c09e6bbf3a0800ef",
+        "g": "585d1a52b35dfa92",
         "name": "0",
         "active": true,
         "tosidebar": false,
@@ -16957,10 +13009,10 @@
         "wires": []
     },
     {
-        "id": "66536c91bfd8a1f5",
+        "id": "8525462b2dad264e",
         "type": "debug",
-        "z": "9e39224fc3ece381",
-        "g": "bdf4f6805cf509e0",
+        "z": "c09e6bbf3a0800ef",
+        "g": "585d1a52b35dfa92",
         "name": "B",
         "active": true,
         "tosidebar": false,
@@ -16975,10 +13027,10 @@
         "wires": []
     },
     {
-        "id": "b090157c45157616",
+        "id": "89593c2befd0636d",
         "type": "debug",
-        "z": "9e39224fc3ece381",
-        "g": "bdf4f6805cf509e0",
+        "z": "c09e6bbf3a0800ef",
+        "g": "585d1a52b35dfa92",
         "name": "0",
         "active": true,
         "tosidebar": false,
@@ -16993,10 +13045,10 @@
         "wires": []
     },
     {
-        "id": "88c9e4aef0a3943e",
+        "id": "89cab6d8692ea12d",
         "type": "debug",
-        "z": "9e39224fc3ece381",
-        "g": "d19e5ec6b8c9a4d5",
+        "z": "c09e6bbf3a0800ef",
+        "g": "5b8e1b80e73b4fc8",
         "name": "Target",
         "active": true,
         "tosidebar": false,
@@ -17011,10 +13063,10 @@
         "wires": []
     },
     {
-        "id": "8278c04dbb97c853",
+        "id": "c2e1c79a0bc998ac",
         "type": "api-current-state",
-        "z": "9e39224fc3ece381",
-        "g": "6c47c0a8eb698b4d",
+        "z": "c09e6bbf3a0800ef",
+        "g": "93bc9508e5ce3a86",
         "name": "Period C start",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -17057,15 +13109,15 @@
         "y": 320,
         "wires": [
             [
-                "5765d286d3f60ed6"
+                "1e2448d228add1e8"
             ]
         ]
     },
     {
-        "id": "5765d286d3f60ed6",
+        "id": "1e2448d228add1e8",
         "type": "api-current-state",
-        "z": "9e39224fc3ece381",
-        "g": "6c47c0a8eb698b4d",
+        "z": "c09e6bbf3a0800ef",
+        "g": "93bc9508e5ce3a86",
         "name": "Period C end",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -17108,15 +13160,15 @@
         "y": 320,
         "wires": [
             [
-                "552135bb95d425ef"
+                "d94002834ee44a50"
             ]
         ]
     },
     {
-        "id": "552135bb95d425ef",
+        "id": "d94002834ee44a50",
         "type": "api-current-state",
-        "z": "9e39224fc3ece381",
-        "g": "6c47c0a8eb698b4d",
+        "z": "c09e6bbf3a0800ef",
+        "g": "93bc9508e5ce3a86",
         "name": "Strat during C",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -17159,15 +13211,15 @@
         "y": 320,
         "wires": [
             [
-                "f30fcd3659ee7c20"
+                "b5d09f0f33171291"
             ]
         ]
     },
     {
-        "id": "0af565b205e2a70a",
+        "id": "72debbc7da5632d8",
         "type": "api-current-state",
-        "z": "9e39224fc3ece381",
-        "g": "6c47c0a8eb698b4d",
+        "z": "c09e6bbf3a0800ef",
+        "g": "93bc9508e5ce3a86",
         "name": "Has period C",
         "server": "176d29a.6f648d6",
         "version": 3,
@@ -17210,15 +13262,15 @@
         "y": 320,
         "wires": [
             [
-                "8278c04dbb97c853"
+                "c2e1c79a0bc998ac"
             ]
         ]
     },
     {
-        "id": "c3fd307b8271989b",
+        "id": "05d201d74c13fab1",
         "type": "switch",
-        "z": "9e39224fc3ece381",
-        "g": "bdf4f6805cf509e0",
+        "z": "c09e6bbf3a0800ef",
+        "g": "585d1a52b35dfa92",
         "name": "has period C",
         "property": "house_battery_strategy_timed_has_period_c",
         "propertyType": "msg",
@@ -17241,19 +13293,19 @@
         "y": 640,
         "wires": [
             [
-                "5dbf89cce4010125",
-                "b090157c45157616"
+                "8dd679613f4a188a",
+                "89593c2befd0636d"
             ],
             [
-                "d8e50e39d010a883"
+                "c241c66d92808042"
             ]
         ]
     },
     {
-        "id": "617af82ac31cf020",
+        "id": "07d1980ba5b9756d",
         "type": "debug",
-        "z": "9e39224fc3ece381",
-        "g": "bdf4f6805cf509e0",
+        "z": "c09e6bbf3a0800ef",
+        "g": "585d1a52b35dfa92",
         "name": "C",
         "active": true,
         "tosidebar": false,
@@ -17268,10 +13320,10 @@
         "wires": []
     },
     {
-        "id": "d8e50e39d010a883",
+        "id": "c241c66d92808042",
         "type": "function",
-        "z": "9e39224fc3ece381",
-        "g": "bdf4f6805cf509e0",
+        "z": "c09e6bbf3a0800ef",
+        "g": "585d1a52b35dfa92",
         "name": "config C",
         "func": "msg.__config = {\n    startTime: RED.util.getMessageProperty(msg,'house_battery_strategy_timed_period_c1'),\n    endTime: RED.util.getMessageProperty(msg,'house_battery_strategy_timed_period_c2'),\n    startOffset: 0,\n    endOffset: 0\n}\n  \nreturn msg;",
         "outputs": 1,
@@ -17284,15 +13336,15 @@
         "y": 720,
         "wires": [
             [
-                "3d49961ac821220e"
+                "dbb15ac56eac7dd5"
             ]
         ]
     },
     {
-        "id": "3d49961ac821220e",
+        "id": "dbb15ac56eac7dd5",
         "type": "time-range-switch",
-        "z": "9e39224fc3ece381",
-        "g": "bdf4f6805cf509e0",
+        "z": "c09e6bbf3a0800ef",
+        "g": "585d1a52b35dfa92",
         "name": "Period C",
         "lat": "",
         "lon": "",
@@ -17304,18 +13356,18 @@
         "y": 720,
         "wires": [
             [
-                "1d78d845ee5ea7dd"
+                "60f6b679d99d0d9f"
             ],
             [
-                "f4640b7dc4624dc0"
+                "54b7ea24d85ba059"
             ]
         ]
     },
     {
-        "id": "1d78d845ee5ea7dd",
+        "id": "60f6b679d99d0d9f",
         "type": "change",
-        "z": "9e39224fc3ece381",
-        "g": "bdf4f6805cf509e0",
+        "z": "c09e6bbf3a0800ef",
+        "g": "585d1a52b35dfa92",
         "name": "set Strat C",
         "rules": [
             {
@@ -17335,16 +13387,16 @@
         "y": 700,
         "wires": [
             [
-                "617af82ac31cf020",
-                "5dbf89cce4010125"
+                "07d1980ba5b9756d",
+                "8dd679613f4a188a"
             ]
         ]
     },
     {
-        "id": "f4640b7dc4624dc0",
+        "id": "54b7ea24d85ba059",
         "type": "change",
-        "z": "9e39224fc3ece381",
-        "g": "bdf4f6805cf509e0",
+        "z": "c09e6bbf3a0800ef",
+        "g": "585d1a52b35dfa92",
         "name": "set Strat 0",
         "rules": [
             {
@@ -17364,16 +13416,16 @@
         "y": 740,
         "wires": [
             [
-                "5dbf89cce4010125",
-                "2afcd77cf7146900"
+                "8dd679613f4a188a",
+                "bae4b34ea1057b55"
             ]
         ]
     },
     {
-        "id": "2afcd77cf7146900",
+        "id": "bae4b34ea1057b55",
         "type": "debug",
-        "z": "9e39224fc3ece381",
-        "g": "bdf4f6805cf509e0",
+        "z": "c09e6bbf3a0800ef",
+        "g": "585d1a52b35dfa92",
         "name": "0",
         "active": true,
         "tosidebar": false,
@@ -17388,10 +13440,10 @@
         "wires": []
     },
     {
-        "id": "722fe0c2ad88122e",
+        "id": "a1eb9a3022f44c9c",
         "type": "change",
-        "z": "9e39224fc3ece381",
-        "g": "f638c541e43f0f69",
+        "z": "c09e6bbf3a0800ef",
+        "g": "abcad92e2e6ee7b8",
         "name": "Trace",
         "rules": [
             {
@@ -17411,16 +13463,16 @@
         "y": 200,
         "wires": [
             [
-                "1c93b6485d540087"
+                "d2de59203f47d4c6"
             ]
         ],
         "info": "Attaches a breadcrumb trace to the msg\r\nso the user can reconstruct which route has\r\nbeen traveled"
     },
     {
-        "id": "bc7a4236b52f0c97",
+        "id": "1631387d18e1c2c0",
         "type": "catch",
-        "z": "9e39224fc3ece381",
-        "g": "811b50295a18f19b",
+        "z": "c09e6bbf3a0800ef",
+        "g": "cd2f5d10eb8a15b5",
         "name": "",
         "scope": null,
         "uncaught": false,
@@ -17428,16 +13480,16 @@
         "y": 320,
         "wires": [
             [
-                "ad82d7e9af9edabd"
+                "d30b9008dd94d727"
             ]
         ],
         "l": false
     },
     {
-        "id": "ad82d7e9af9edabd",
+        "id": "d30b9008dd94d727",
         "type": "function",
-        "z": "9e39224fc3ece381",
-        "g": "811b50295a18f19b",
+        "z": "c09e6bbf3a0800ef",
+        "g": "cd2f5d10eb8a15b5",
         "name": "Unhandled Exception",
         "func": "const handle = global.get('unhandledException');\n\nhandle(this);\n\nreturn msg;",
         "outputs": 1,
@@ -17450,16 +13502,16 @@
         "y": 320,
         "wires": [
             [
-                "999c90deaf101f4c"
+                "8ab1c24939e9c7d6"
             ]
         ],
         "l": false
     },
     {
-        "id": "999c90deaf101f4c",
+        "id": "8ab1c24939e9c7d6",
         "type": "link out",
-        "z": "9e39224fc3ece381",
-        "g": "811b50295a18f19b",
+        "z": "c09e6bbf3a0800ef",
+        "g": "cd2f5d10eb8a15b5",
         "name": "link out 8",
         "mode": "return",
         "links": [],


### PR DESCRIPTION
This PR reworks #104 (originally by @nickles-lee, field-tested by @Stievo9997) with the following changes:

## What changed vs #104
- Support extended to **6 batteries** (M5–M6) instead of 8, as discussed in #104 — 6 is the practical maximum for 3-phase homes (2 batteries per phase)
- Rebased on current main (v4.6.3) rather than the old base (v4.6.1)
- Version bumped to **v4.7.0** (minor bump, as this is a new feature on top of v4.6.3)

## Changes
- Dashboard: M5/M6 glance cards, history-graph entries, and per-battery config grids
- \house_battery_control.yaml\: M5/M6 \input_number\ helpers, \max: 6\ for battery count and prioritize selectors, M5/M6 added to total battery power template sensor
- Docs: updated multi-battery section to reflect 6-battery support

Closes #103
