### PR TITLE
Tests: add Node-RED tests for current status quo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,15 @@ RELEASE_NOTES_TEMP.txt
 notes/
 template_sensor_bob_battery_dashboard.yaml
 
-# Ignore SASS cache files
+# Ignore opencode local workspace
+.opencode/
+
 docs/.sass-cache
+
+# Node.js dependencies and test output
+node_modules/
+
+coverage/
 
 # Claude Code per-user state — keep local; commands/skills/agents/settings.json are shared
 .claude/settings.local.json

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: setup test test-unit test-integration
+
+setup:
+	npm ci
+
+test:
+	npm test
+
+test-unit:
+	npm run test:unit
+
+test-integration:
+	npm run test:integration

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,245 @@
+{
+  "name": "marstek-venus-rs485-node-red-tests",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "marstek-venus-rs485-node-red-tests",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@node-red/util": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@node-red/util": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@node-red/util/-/util-4.1.11.tgz",
+      "integrity": "sha512-+rYoiuRkB9f5RFs1Rz1HNo9fC8lIAPrW1mIkDXCoTjAD/iDjAth7BRxcOSB1JCXpbV+ncj9Ger40S+UgVAUVRg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "fs-extra": "11.3.0",
+        "i18next": "25.8.14",
+        "json-stringify-safe": "5.0.1",
+        "jsonata": "2.0.6",
+        "lodash.clonedeep": "^4.5.0",
+        "moment": "2.30.1",
+        "moment-timezone": "0.5.48"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "25.8.14",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.8.14.tgz",
+      "integrity": "sha512-paMUYkfWJMsWPeE/Hejcw+XLhHrQPehem+4wMo+uELnvIwvCG019L9sAIljwjCmEMtFQQO3YeitJY8Kctei3iA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jsonata": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/jsonata/-/jsonata-2.0.6.tgz",
+      "integrity": "sha512-WhQB5tXQ32qjkx2GYHFw2XbL90u+LLzjofAYwi+86g6SyZeXHz9F1Q0amy3dWRYczshOC3Haok9J4pOCgHtwyQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.48",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.48.tgz",
+      "integrity": "sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "marstek-venus-rs485-node-red-tests",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Local unit and integration tests for Home Battery Control Node-RED strategies",
+  "scripts": {
+    "test": "node --test test/**/*.test.js",
+    "test:unit": "node --test test/unit/**/*.test.js",
+    "test:integration": "node --test test/integration/**/*.test.js"
+  },
+  "devDependencies": {
+    "@node-red/util": "^4.0.0"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "description": "Local unit and integration tests for Home Battery Control Node-RED strategies",
   "scripts": {
-    "test": "node --test test/**/*.test.js",
-    "test:unit": "node --test test/unit/**/*.test.js",
-    "test:integration": "node --test test/integration/**/*.test.js"
+    "test": "node --test $(find test -type f -name '*.test.js' | sort)",
+    "test:unit": "node --test $(find test/unit -type f -name '*.test.js' | sort)",
+    "test:integration": "node --test $(find test/integration -type f -name '*.test.js' | sort)"
   },
   "devDependencies": {
     "@node-red/util": "^4.0.0"

--- a/test/fixtures/expectations.js
+++ b/test/fixtures/expectations.js
@@ -1,0 +1,25 @@
+'use strict';
+
+function expectSolutions(actual, expectedById) {
+  if (!Array.isArray(actual)) {
+    throw new Error(`expected solutions array, got ${typeof actual}`);
+  }
+  const byId = Object.fromEntries(actual.map((s) => [s.id, s]));
+  for (const [id, expected] of Object.entries(expectedById)) {
+    const solution = byId[id];
+    if (!solution) {
+      throw new Error(`expected solution for ${id} but not found`);
+    }
+    if (expected.mode !== undefined && solution.mode !== expected.mode) {
+      throw new Error(`expected ${id} mode ${expected.mode}, got ${solution.mode}`);
+    }
+    if (expected.power !== undefined && solution.power !== expected.power) {
+      throw new Error(`expected ${id} power ${expected.power}, got ${solution.power}`);
+    }
+  }
+  if (actual.length !== Object.keys(expectedById).length) {
+    throw new Error(`expected ${Object.keys(expectedById).length} solutions, got ${actual.length}`);
+  }
+}
+
+module.exports = { expectSolutions };

--- a/test/fixtures/homes.js
+++ b/test/fixtures/homes.js
@@ -1,0 +1,102 @@
+'use strict';
+
+const DEFAULTS = {
+  venusE: {
+    capacityKwh: 5,
+    chargeMaxW: 2500,
+    dischargeMaxW: 2500,
+  },
+  venusA: {
+    capacityKwh: 12.46,
+    chargeMaxW: 1500,
+    dischargeMaxW: 1500,
+  },
+};
+
+function makeBattery({
+  id,
+  phase = 'unassigned',
+  soc = 50,
+  socMin = 10,
+  socMax = 100,
+  chargeMaxW = DEFAULTS.venusE.chargeMaxW,
+  dischargeMaxW = DEFAULTS.venusE.dischargeMaxW,
+  energyMaxKwh = DEFAULTS.venusE.capacityKwh,
+  power = 0,
+  rs485 = 'enable',
+  lastCommand = null,
+}) {
+  return {
+    id,
+    phase,
+    power,
+    charging_max: chargeMaxW,
+    discharging_max: dischargeMaxW,
+    soc,
+    soc_max: socMax,
+    soc_min: socMin,
+    inverter: 'on',
+    energy: Number(((energyMaxKwh * soc) / 100).toFixed(3)),
+    energy_max: energyMaxKwh,
+    rs485,
+    last_command: lastCommand,
+  };
+}
+
+function singleVenusE(overrides = {}) {
+  return [makeBattery({ id: 'M1', ...DEFAULTS.venusE, ...overrides })];
+}
+
+function singleVenusEThrottled(overrides = {}) {
+  return [
+    makeBattery({
+      id: 'M1',
+      chargeMaxW: 2500,
+      dischargeMaxW: 800,
+      ...overrides,
+    }),
+  ];
+}
+
+function oneVenusEPerPhase(overridesPerBattery = []) {
+  return ['L1', 'L2', 'L3'].map((phase, index) =>
+    makeBattery({
+      id: `M${index + 1}`,
+      phase,
+      ...(overridesPerBattery[index] || {}),
+    })
+  );
+}
+
+function twoVenusEPerPhase(overridesPerBattery = []) {
+  const phases = ['L1', 'L1', 'L2', 'L2', 'L3', 'L3'];
+  return phases.map((phase, index) =>
+    makeBattery({
+      id: `M${index + 1}`,
+      phase,
+      ...(overridesPerBattery[index] || {}),
+    })
+  );
+}
+
+function heterogeneousSystem(overridesPerBattery = []) {
+  const definitions = [
+    { id: 'M1', phase: 'L3', chargeMaxW: 2200, dischargeMaxW: 2500 },
+    { id: 'M2', phase: 'L3', chargeMaxW: 1750, dischargeMaxW: 1750 },
+    { id: 'M3', phase: 'L2' },
+    { id: 'M4', phase: 'L1' },
+    { id: 'M5', phase: 'L3', capacityKwh: 12.46, chargeMaxW: 1500, dischargeMaxW: 1500 },
+  ];
+  return definitions.map((def, index) =>
+    makeBattery({ ...def, ...(overridesPerBattery[index] || {}) })
+  );
+}
+
+module.exports = {
+  makeBattery,
+  singleVenusE,
+  singleVenusEThrottled,
+  oneVenusEPerPhase,
+  twoVenusEPerPhase,
+  heterogeneousSystem,
+};

--- a/test/integration/strategy-charge.test.js
+++ b/test/integration/strategy-charge.test.js
@@ -1,0 +1,93 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { FlowGraph } = require('../lib/flow-graph');
+const { Initializer } = require('../support/init-flow');
+const { ContextStore } = require('../lib/context-store');
+const { StateProvider } = require('../lib/ha-state-mock');
+const { twoVenusEPerPhase, singleVenusEThrottled } = require('../fixtures/homes');
+
+describe('Charge strategy integration', () => {
+  it('charges at max power without limits', async () => {
+    const initializer = new Initializer();
+    initializer.useNoopLogger();
+
+    const graph = new FlowGraph({
+      context: new ContextStore(),
+      flow: new ContextStore(),
+      global: initializer.global,
+    });
+    graph.load(['node-red/02 strategy-charge.json']);
+
+    const state = new Map([
+      ['input_boolean.house_battery_grid_power_has_limit_import', 'off'],
+      ['input_select.house_battery_strategy_charge_goal', 'batteries are full'],
+    ]);
+
+    const msg = {
+      batteries: singleVenusEThrottled(),
+      grid_power_has_limit_import: false,
+      phase_protection: {
+        enabled: false,
+        command_limits_available: false,
+        command_limit_by_phase: {
+          charge: { L1: null, L2: null, L3: null },
+          discharge: { L1: null, L2: null, L3: null },
+        },
+      },
+    };
+
+    graph.stateProvider = new StateProvider(state);
+    const terminals = await graph.run('Charge', msg);
+
+    assert.equal(terminals.length, 1);
+    assert.deepEqual(terminals[0].solutions, [
+      { id: 'M1', mode: 'charge', power: 2500 },
+    ]);
+  });
+
+  it('throttles max-power charge when phase command limits are lower', async () => {
+    const initializer = new Initializer();
+    initializer.useNoopLogger();
+
+    const graph = new FlowGraph({
+      context: new ContextStore(),
+      flow: new ContextStore(),
+      global: initializer.global,
+    });
+    graph.load(['node-red/02 strategy-charge.json']);
+
+    const state = new Map([
+      ['input_boolean.house_battery_grid_power_has_limit_import', 'off'],
+      ['input_select.house_battery_strategy_charge_goal', 'batteries are full'],
+    ]);
+
+    const msg = {
+      batteries: twoVenusEPerPhase(),
+      grid_power_has_limit_import: false,
+      phase_protection: {
+        enabled: false,
+        command_limits_available: true,
+        command_limit_by_phase: {
+          charge: { L1: 3000, L2: 3000, L3: 3000 },
+          discharge: { L1: null, L2: null, L3: null },
+        },
+      },
+    };
+
+    graph.stateProvider = new StateProvider(state);
+    const terminals = await graph.run('Charge', msg);
+
+    assert.equal(terminals.length, 1);
+    // First-fit allocation on each phase: each battery wants 2500W; phase limit 3000
+    // first battery gets 2500, second gets remaining 500.
+    const solutions = terminals[0].solutions;
+    assert.equal(solutions[0].power, 2500);
+    assert.equal(solutions[1].power, 500);
+    assert.equal(solutions[2].power, 2500);
+    assert.equal(solutions[3].power, 500);
+    assert.equal(solutions[4].power, 2500);
+    assert.equal(solutions[5].power, 500);
+  });
+});

--- a/test/integration/strategy-charge.test.js
+++ b/test/integration/strategy-charge.test.js
@@ -1,12 +1,16 @@
 'use strict';
 
+// NOTE: The `phase_protection` payload is preserved in these tests even though
+// the current `main` branch does not implement phase-aware throttling. It will
+// become relevant in the upcoming phase-protection PR, keeping future diffs small.
+
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
 const { FlowGraph } = require('../lib/flow-graph');
 const { Initializer } = require('../support/init-flow');
 const { ContextStore } = require('../lib/context-store');
 const { StateProvider } = require('../lib/ha-state-mock');
-const { twoVenusEPerPhase, singleVenusEThrottled } = require('../fixtures/homes');
+const { singleVenusEThrottled } = require('../fixtures/homes');
 
 describe('Charge strategy integration', () => {
   it('charges at max power without limits', async () => {
@@ -47,47 +51,4 @@ describe('Charge strategy integration', () => {
     ]);
   });
 
-  it('throttles max-power charge when phase command limits are lower', async () => {
-    const initializer = new Initializer();
-    initializer.useNoopLogger();
-
-    const graph = new FlowGraph({
-      context: new ContextStore(),
-      flow: new ContextStore(),
-      global: initializer.global,
-    });
-    graph.load(['node-red/02 strategy-charge.json']);
-
-    const state = new Map([
-      ['input_boolean.house_battery_grid_power_has_limit_import', 'off'],
-      ['input_select.house_battery_strategy_charge_goal', 'batteries are full'],
-    ]);
-
-    const msg = {
-      batteries: twoVenusEPerPhase(),
-      grid_power_has_limit_import: false,
-      phase_protection: {
-        enabled: false,
-        command_limits_available: true,
-        command_limit_by_phase: {
-          charge: { L1: 3000, L2: 3000, L3: 3000 },
-          discharge: { L1: null, L2: null, L3: null },
-        },
-      },
-    };
-
-    graph.stateProvider = new StateProvider(state);
-    const terminals = await graph.run('Charge', msg);
-
-    assert.equal(terminals.length, 1);
-    // First-fit allocation on each phase: each battery wants 2500W; phase limit 3000
-    // first battery gets 2500, second gets remaining 500.
-    const solutions = terminals[0].solutions;
-    assert.equal(solutions[0].power, 2500);
-    assert.equal(solutions[1].power, 500);
-    assert.equal(solutions[2].power, 2500);
-    assert.equal(solutions[3].power, 500);
-    assert.equal(solutions[4].power, 2500);
-    assert.equal(solutions[5].power, 500);
-  });
 });

--- a/test/integration/strategy-full-stop.test.js
+++ b/test/integration/strategy-full-stop.test.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { FlowGraph } = require('../lib/flow-graph');
+const { Initializer } = require('../support/init-flow');
+const { ContextStore } = require('../lib/context-store');
+const { singleVenusE } = require('../fixtures/homes');
+
+describe('Full stop strategy integration', () => {
+  it('walks from link in to link out and stops every battery', async () => {
+    const initializer = new Initializer();
+    initializer.useNoopLogger();
+
+    const context = new ContextStore();
+    const flow = new ContextStore();
+    const globalStore = initializer.global;
+
+    const graph = new FlowGraph({ context, flow, global: globalStore });
+    graph.load(['node-red/02 strategy-full-stop.json']);
+
+    const msg = { batteries: singleVenusE() };
+    const terminals = await graph.run('Full stop', msg);
+
+    assert.equal(terminals.length, 1);
+    assert.deepEqual(terminals[0].solutions, [
+      { id: 'M1', mode: 'stop', power: 0 },
+    ]);
+  });
+});

--- a/test/integration/strategy-partials.test.js
+++ b/test/integration/strategy-partials.test.js
@@ -1,0 +1,107 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { FlowGraph } = require('../lib/flow-graph');
+const { Initializer } = require('../support/init-flow');
+const { ContextStore } = require('../lib/context-store');
+const { StateProvider } = require('../lib/ha-state-mock');
+const { oneVenusEPerPhase } = require('../fixtures/homes');
+
+describe('Partials strategy integration', () => {
+  it('peak shaves import by discharging when grid power exceeds import limit', async () => {
+    const initializer = new Initializer();
+    initializer.useNoopLogger();
+
+    const graph = new FlowGraph({
+      context: new ContextStore(),
+      flow: new ContextStore(),
+      global: initializer.global,
+    });
+
+    graph.load([
+      'node-red/02 strategy-partials.json',
+      'node-red/02 strategy-self-consumption.json',
+      'node-red/02 strategy-full-stop.json',
+    ]);
+
+    const state = new Map([
+      ['input_boolean.house_battery_grid_power_has_limit_import', 'on'],
+      ['input_number.house_battery_grid_power_limit_import', '2500'],
+      ['input_boolean.house_battery_grid_power_has_limit_export', 'off'],
+    ]);
+
+    const msg = {
+      target: 'Standby / peak shave',
+      batteries: oneVenusEPerPhase([{ soc: 90 }, { soc: 90 }, { soc: 90 }]),
+      grid_power: 5000,
+      grid_power_limit_import: 2500,
+      grid_power_has_limit_import: true,
+      grid_power_has_limit_export: false,
+      advanced_settings: {},
+      phase_protection: {
+        enabled: false,
+        command_limits_available: false,
+        command_limit_by_phase: {
+          charge: { L1: null, L2: null, L3: null },
+          discharge: { L1: null, L2: null, L3: null },
+        },
+      },
+    };
+
+    graph.stateProvider = new StateProvider(state);
+    const terminals = await graph.run('Standby / peak shave', msg);
+
+    assert.equal(terminals.length, 1);
+    assert.equal(terminals[0].solutions.length, 3);
+    assert.ok(terminals[0].solutions.every((s) => s.mode === 'discharge' && s.power > 0));
+  });
+
+  it('peak shaves export by charging when grid power exceeds export limit', async () => {
+    const initializer = new Initializer();
+    initializer.useNoopLogger();
+
+    const graph = new FlowGraph({
+      context: new ContextStore(),
+      flow: new ContextStore(),
+      global: initializer.global,
+    });
+
+    graph.load([
+      'node-red/02 strategy-partials.json',
+      'node-red/02 strategy-self-consumption.json',
+      'node-red/02 strategy-full-stop.json',
+    ]);
+
+    const state = new Map([
+      ['input_boolean.house_battery_grid_power_has_limit_export', 'on'],
+      ['input_number.house_battery_grid_power_limit_export', '2500'],
+      ['input_boolean.house_battery_grid_power_has_limit_import', 'off'],
+    ]);
+
+    const msg = {
+      target: 'Standby / peak shave',
+      batteries: oneVenusEPerPhase([{ soc: 50 }, { soc: 50 }, { soc: 50 }]),
+      grid_power: -5000,
+      grid_power_limit_export: 2500,
+      grid_power_has_limit_import: false,
+      grid_power_has_limit_export: true,
+      advanced_settings: {},
+      phase_protection: {
+        enabled: false,
+        command_limits_available: false,
+        command_limit_by_phase: {
+          charge: { L1: null, L2: null, L3: null },
+          discharge: { L1: null, L2: null, L3: null },
+        },
+      },
+    };
+
+    graph.stateProvider = new StateProvider(state);
+    const terminals = await graph.run('Standby / peak shave', msg);
+
+    assert.equal(terminals.length, 1);
+    assert.equal(terminals[0].solutions.length, 3);
+    assert.ok(terminals[0].solutions.every((s) => s.mode === 'charge' && s.power > 0));
+  });
+});

--- a/test/integration/strategy-partials.test.js
+++ b/test/integration/strategy-partials.test.js
@@ -1,5 +1,9 @@
 'use strict';
 
+// NOTE: The `phase_protection` payload is preserved in these tests even though
+// the current `main` branch does not implement phase-aware throttling. It will
+// become relevant in the upcoming phase-protection PR, keeping future diffs small.
+
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
 const { FlowGraph } = require('../lib/flow-graph');

--- a/test/integration/strategy-self-consumption.test.js
+++ b/test/integration/strategy-self-consumption.test.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { FlowGraph } = require('../lib/flow-graph');
+const { Initializer } = require('../support/init-flow');
+const { ContextStore } = require('../lib/context-store');
+const { StateProvider } = require('../lib/ha-state-mock');
+const { twoVenusEPerPhase, oneVenusEPerPhase } = require('../fixtures/homes');
+
+describe('Self-consumption strategy integration', () => {
+  it('charges surplus power when exporting to the grid', async () => {
+    const initializer = new Initializer();
+    initializer.useNoopLogger();
+
+    const graph = new FlowGraph({
+      context: new ContextStore(),
+      flow: new ContextStore(),
+      global: initializer.global,
+    });
+    graph.load(['node-red/02 strategy-self-consumption.json', 'node-red/02 strategy-full-stop.json']);
+
+    const state = new Map([
+      ['input_boolean.house_battery_grid_power_has_limit_export', 'off'],
+    ]);
+
+    const msg = {
+      batteries: twoVenusEPerPhase({ 0: { soc: 50 }, 1: { soc: 50 }, 2: { soc: 50 }, 3: { soc: 50 }, 4: { soc: 50 }, 5: { soc: 50 } }),
+      grid_power: -4000,
+      advanced_settings: {},
+      phase_protection: {
+        enabled: false,
+        command_limits_available: false,
+        command_limit_by_phase: {
+          charge: { L1: null, L2: null, L3: null },
+          discharge: { L1: null, L2: null, L3: null },
+        },
+      },
+    };
+
+    graph.stateProvider = new StateProvider(state);
+    const terminals = await graph.run('Self-consumption', msg);
+
+    assert.equal(terminals.length, 1);
+    assert.equal(terminals[0].solutions.length, 6);
+    assert.ok(terminals[0].solutions.every((s) => s.mode === 'charge' && s.power > 0));
+  });
+
+  it('discharges to cover import when drawing from the grid', async () => {
+    const initializer = new Initializer();
+    initializer.useNoopLogger();
+
+    const graph = new FlowGraph({
+      context: new ContextStore(),
+      flow: new ContextStore(),
+      global: initializer.global,
+    });
+    graph.load(['node-red/02 strategy-self-consumption.json', 'node-red/02 strategy-full-stop.json']);
+
+    const state = new Map([
+      ['input_boolean.house_battery_grid_power_has_limit_import', 'off'],
+    ]);
+
+    const msg = {
+      batteries: oneVenusEPerPhase([{ soc: 90 }, { soc: 90 }, { soc: 90 }]),
+      grid_power: 3000,
+      advanced_settings: {},
+      phase_protection: {
+        enabled: false,
+        command_limits_available: false,
+        command_limit_by_phase: {
+          charge: { L1: null, L2: null, L3: null },
+          discharge: { L1: null, L2: null, L3: null },
+        },
+      },
+    };
+
+    graph.stateProvider = new StateProvider(state);
+    const terminals = await graph.run('Self-consumption', msg);
+
+    assert.equal(terminals.length, 1);
+    assert.equal(terminals[0].solutions.length, 3);
+    assert.ok(terminals[0].solutions.every((s) => s.mode === 'discharge' && s.power > 0));
+  });
+});

--- a/test/integration/strategy-self-consumption.test.js
+++ b/test/integration/strategy-self-consumption.test.js
@@ -1,5 +1,9 @@
 'use strict';
 
+// NOTE: The `phase_protection` payload is preserved in these tests even though
+// the current `main` branch does not implement phase-aware throttling. It will
+// become relevant in the upcoming phase-protection PR, keeping future diffs small.
+
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
 const { FlowGraph } = require('../lib/flow-graph');

--- a/test/integration/strategy-sell.test.js
+++ b/test/integration/strategy-sell.test.js
@@ -1,0 +1,102 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { FlowGraph } = require('../lib/flow-graph');
+const { Initializer } = require('../support/init-flow');
+const { ContextStore } = require('../lib/context-store');
+const { StateProvider } = require('../lib/ha-state-mock');
+const { singleVenusE, twoVenusEPerPhase } = require('../fixtures/homes');
+
+describe('Sell strategy integration', () => {
+  it('discharges at max power without limits', async () => {
+    const initializer = new Initializer();
+    initializer.useNoopLogger();
+
+    const graph = new FlowGraph({
+      context: new ContextStore(),
+      flow: new ContextStore(),
+      global: initializer.global,
+    });
+    graph.load(['node-red/02 strategy-sell.json', 'node-red/02 strategy-full-stop.json']);
+
+    const state = new Map([
+      ['input_boolean.house_battery_grid_power_has_limit_export', 'off'],
+      ['input_select.house_battery_strategy_sell_goal', 'state of charge'],
+      ['input_number.house_battery_strategy_sell_target_soc', '11'],
+      ['input_select.house_battery_strategy_sell_goal_reached', 'Full stop'],
+    ]);
+
+    const msg = {
+      batteries: singleVenusE({ soc: 90 }),
+      grid_power_has_limit_export: false,
+      phase_protection: {
+        enabled: false,
+        command_limits_available: false,
+        command_limit_by_phase: {
+          charge: { L1: null, L2: null, L3: null },
+          discharge: { L1: null, L2: null, L3: null },
+        },
+      },
+    };
+
+    graph.stateProvider = new StateProvider(state);
+    const terminals = await graph.run('Sell', msg);
+
+    assert.equal(terminals.length, 1);
+    assert.deepEqual(terminals[0].solutions, [
+      { id: 'M1', mode: 'discharge', power: 2500 },
+    ]);
+  });
+
+  it('throttles max-power discharge when phase command limits are lower', async () => {
+    const initializer = new Initializer();
+    initializer.useNoopLogger();
+
+    const graph = new FlowGraph({
+      context: new ContextStore(),
+      flow: new ContextStore(),
+      global: initializer.global,
+    });
+    graph.load(['node-red/02 strategy-sell.json', 'node-red/02 strategy-full-stop.json']);
+
+    const state = new Map([
+      ['input_boolean.house_battery_grid_power_has_limit_export', 'off'],
+      ['input_select.house_battery_strategy_sell_goal', 'state of charge'],
+      ['input_number.house_battery_strategy_sell_target_soc', '11'],
+      ['input_select.house_battery_strategy_sell_goal_reached', 'Full stop'],
+    ]);
+
+    const msg = {
+      batteries: twoVenusEPerPhase({
+        0: { soc: 90 },
+        1: { soc: 90 },
+        2: { soc: 90 },
+        3: { soc: 90 },
+        4: { soc: 90 },
+        5: { soc: 90 },
+      }),
+      grid_power_has_limit_export: false,
+      phase_protection: {
+        enabled: false,
+        command_limits_available: true,
+        command_limit_by_phase: {
+          charge: { L1: null, L2: null, L3: null },
+          discharge: { L1: 3000, L2: 3000, L3: 3000 },
+        },
+      },
+    };
+
+    graph.stateProvider = new StateProvider(state);
+    const terminals = await graph.run('Sell', msg);
+
+    assert.equal(terminals.length, 1);
+    const solutions = terminals[0].solutions;
+    assert.equal(solutions[0].power, 2500);
+    assert.equal(solutions[1].power, 500);
+    assert.equal(solutions[2].power, 2500);
+    assert.equal(solutions[3].power, 500);
+    assert.equal(solutions[4].power, 2500);
+    assert.equal(solutions[5].power, 500);
+  });
+});

--- a/test/integration/strategy-sell.test.js
+++ b/test/integration/strategy-sell.test.js
@@ -1,12 +1,16 @@
 'use strict';
 
+// NOTE: The `phase_protection` payload is preserved in these tests even though
+// the current `main` branch does not implement phase-aware throttling. It will
+// become relevant in the upcoming phase-protection PR, keeping future diffs small.
+
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
 const { FlowGraph } = require('../lib/flow-graph');
 const { Initializer } = require('../support/init-flow');
 const { ContextStore } = require('../lib/context-store');
 const { StateProvider } = require('../lib/ha-state-mock');
-const { singleVenusE, twoVenusEPerPhase } = require('../fixtures/homes');
+const { singleVenusE } = require('../fixtures/homes');
 
 describe('Sell strategy integration', () => {
   it('discharges at max power without limits', async () => {
@@ -49,54 +53,4 @@ describe('Sell strategy integration', () => {
     ]);
   });
 
-  it('throttles max-power discharge when phase command limits are lower', async () => {
-    const initializer = new Initializer();
-    initializer.useNoopLogger();
-
-    const graph = new FlowGraph({
-      context: new ContextStore(),
-      flow: new ContextStore(),
-      global: initializer.global,
-    });
-    graph.load(['node-red/02 strategy-sell.json', 'node-red/02 strategy-full-stop.json']);
-
-    const state = new Map([
-      ['input_boolean.house_battery_grid_power_has_limit_export', 'off'],
-      ['input_select.house_battery_strategy_sell_goal', 'state of charge'],
-      ['input_number.house_battery_strategy_sell_target_soc', '11'],
-      ['input_select.house_battery_strategy_sell_goal_reached', 'Full stop'],
-    ]);
-
-    const msg = {
-      batteries: twoVenusEPerPhase({
-        0: { soc: 90 },
-        1: { soc: 90 },
-        2: { soc: 90 },
-        3: { soc: 90 },
-        4: { soc: 90 },
-        5: { soc: 90 },
-      }),
-      grid_power_has_limit_export: false,
-      phase_protection: {
-        enabled: false,
-        command_limits_available: true,
-        command_limit_by_phase: {
-          charge: { L1: null, L2: null, L3: null },
-          discharge: { L1: 3000, L2: 3000, L3: 3000 },
-        },
-      },
-    };
-
-    graph.stateProvider = new StateProvider(state);
-    const terminals = await graph.run('Sell', msg);
-
-    assert.equal(terminals.length, 1);
-    const solutions = terminals[0].solutions;
-    assert.equal(solutions[0].power, 2500);
-    assert.equal(solutions[1].power, 500);
-    assert.equal(solutions[2].power, 2500);
-    assert.equal(solutions[3].power, 500);
-    assert.equal(solutions[4].power, 2500);
-    assert.equal(solutions[5].power, 500);
-  });
 });

--- a/test/lib/context-store.js
+++ b/test/lib/context-store.js
@@ -1,0 +1,35 @@
+'use strict';
+
+class ContextStore {
+  /**
+   * @param {Record<string, unknown>} [initial]
+   */
+  constructor(initial = {}) {
+    this.store = new Map(Object.entries(initial));
+  }
+
+  /**
+   * @param {string} key
+   */
+  get(key) {
+    return this.store.get(key);
+  }
+
+  /**
+   * @param {string} key
+   * @param {unknown} value
+   */
+  set(key, value) {
+    this.store.set(key, value);
+    return value;
+  }
+
+  /**
+   * @returns {string[]}
+   */
+  keys() {
+    return Array.from(this.store.keys());
+  }
+}
+
+module.exports = { ContextStore };

--- a/test/lib/flow-graph.js
+++ b/test/lib/flow-graph.js
@@ -1,0 +1,352 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const RED = require('./red-util');
+const { FunctionRunner } = require('./function-runner');
+const { resolveTemplate, StateProvider, TemplateProvider } = require('./ha-state-mock');
+
+function convertRuleValue(value, type, msg, stores) {
+  switch (type) {
+    case 'str': return String(value);
+    case 'num': return Number(value);
+    case 'bool': return value === true || value === 'true';
+    case 're': return new RegExp(value);
+    case 'flow': return stores.flow.get(value);
+    case 'global': return stores.global.get(value);
+    case 'msg': return RED.getMessageProperty(msg, value);
+    default: return value;
+  }
+}
+
+class FlowGraph {
+  /**
+   * @param {object} options
+   * @param {ContextStore} options.context
+   * @param {ContextStore} options.flow
+   * @param {ContextStore} options.global
+   * @param {StateProvider} [options.stateProvider]
+   * @param {TemplateProvider} [options.templateProvider]
+   * @param {object} [options.clock]
+   */
+  constructor(options = {}) {
+    this.nodes = new Map();
+    this.configNodes = new Map();
+    this.idsByName = new Map();
+    this.context = options.context;
+    this.flow = options.flow;
+    this.global = options.global;
+    this.stateProvider = options.stateProvider || new StateProvider();
+    this.templateProvider = options.templateProvider || new TemplateProvider();
+    this.clock = options.clock || { now: () => Date.now() };
+    this.runner = new FunctionRunner({ captureStatus: false, captureWarnings: true, captureErrors: true, captureLogs: false });
+    this.maxDepth = 200;
+    this.onVisit = options.onVisit;
+  }
+
+  load(flowFiles) {
+    for (const file of flowFiles) {
+      const fullPath = path.resolve(__dirname, '../../', file);
+      const flow = JSON.parse(fs.readFileSync(fullPath, 'utf8'));
+      for (const node of flow) {
+        if (!node || !node.id) continue;
+        if (node.type === 'server' || node.type === 'global-config') {
+          this.configNodes.set(node.id, node);
+          continue;
+        }
+        if (!this.nodes.has(node.id)) {
+          this.nodes.set(node.id, node);
+          if (node.name) {
+            const key = `${node.type}:${node.name}`;
+            if (!this.idsByName.has(key)) {
+              this.idsByName.set(key, node.id);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  getNode(id) { return this.nodes.get(id); }
+  getNodeIdByName(type, name) { return this.idsByName.get(`${type}:${name}`); }
+  getNodeByName(type, name) { return this.nodes.get(this.getNodeIdByName(type, name)); }
+
+  /**
+   * Start at a strategy `link in` by name and run until terminal `link out` return.
+   * @param {string} strategyName
+   * @param {object} startMsg
+   * @returns {Promise<object[]>} terminal messages from link out return nodes
+   */
+  async run(strategyName, startMsg) {
+    const startNode = this.getNodeByName('link in', strategyName);
+    if (!startNode) {
+      throw new Error(`link in "${strategyName}" not found`);
+    }
+    const terminals = [];
+    await this._visit(startNode.id, startMsg, 0, terminals);
+    return terminals;
+  }
+
+  async _visit(nodeId, msg, depth, terminals) {
+    if (depth > this.maxDepth) {
+      throw new Error(`Max traversal depth exceeded at node ${nodeId}`);
+    }
+    const node = this.nodes.get(nodeId);
+    if (!node) return;
+    if (this.onVisit) this.onVisit(node, msg, depth);
+
+    const result = await this._execNode(node, msg, depth);
+
+    if (node.type === 'link out') {
+      if (node.mode === 'return') {
+        terminals.push(msg);
+        return;
+      }
+      // Static link to another node (usually link in "link to End")
+      for (const targetId of node.links || []) {
+        await this._visit(targetId, msg, depth + 1, terminals);
+      }
+      return;
+    }
+
+    for (let i = 0; i < result.length; i++) {
+      const outMsg = result[i];
+      if (outMsg === null || outMsg === undefined) continue;
+      const wires = node.wires?.[i] || [];
+      for (const targetId of wires) {
+        await this._visit(targetId, outMsg, depth + 1, terminals);
+      }
+    }
+  }
+
+  async _execNode(node, msg, depth) {
+    const stores = { context: this.context, flow: this.flow, global: this.global };
+
+    switch (node.type) {
+      case 'function': {
+        const result = this.runner.run({ node, msg, context: this.context, flow: this.flow, global: this.global });
+        return this._functionOutputs(node, result);
+      }
+      case 'change': return this._applyChangeRules(node, msg);
+      case 'switch': return this._evalSwitch(node, msg);
+      case 'link in': return [msg];
+      case 'link out': return [];
+      case 'link call': return this._evalLinkCall(node, msg, depth);
+      case 'api-current-state': return this._evalApiCurrentState(node, msg);
+      case 'api-call-service': return [msg];
+      case 'api-render-template': return this._evalApiRenderTemplate(node, msg);
+      case 'time-range-switch': return this._evalTimeRangeSwitch(node, msg);
+      case 'rbe':
+      case 'smooth':
+      case 'delay':
+      case 'trigger':
+      case 'inject':
+      case 'junction': return [msg];
+      case 'debug': return [];
+      default: return [msg];
+    }
+  }
+
+  _functionOutputs(node, result) {
+    if (result === null || result === undefined) return [];
+    if (Array.isArray(result) && (node.outputs || 1) > 1) {
+      const arr = result.slice(0, node.outputs);
+      while (arr.length < node.outputs) arr.push(undefined);
+      return arr;
+    }
+    return [result];
+  }
+
+  _applyChangeRules(node, msg) {
+    for (const rule of node.rules || []) {
+      const p = rule.p;
+      const pt = rule.pt || 'msg';
+      switch (rule.t) {
+        case 'set': {
+          let value;
+          if (rule.tot === 'entityState') {
+            value = this.stateProvider.getState(resolveTemplate(node.entity_id, msg));
+          } else {
+            value = this._convertValue(rule.to, rule.tot, msg);
+          }
+          this._setProperty(pt, p, value, msg);
+          break;
+        }
+        case 'delete': {
+          this._deleteProperty(pt, p, msg);
+          break;
+        }
+        case 'move': {
+          const src = this._getProperty(rule.p, msg);
+          this._deleteProperty(pt, rule.p, msg);
+          this._setProperty(rule.to_pt || 'msg', rule.to, src, msg);
+          break;
+        }
+        case 'change': {
+          const current = this._getProperty(pt, p, msg);
+          if (typeof current === 'string') {
+            const from = new RegExp(rule.from, 'g');
+            this._setProperty(pt, p, current.replace(from, rule.to), msg);
+          }
+          break;
+        }
+      }
+    }
+    return [msg];
+  }
+
+  _getProperty(pt, p, msg) {
+    if (pt === 'msg') return RED.getMessageProperty(msg, p);
+    if (pt === 'flow') return this.flow.get(p);
+    if (pt === 'global') return this.global.get(p);
+    if (pt === 'payload') return msg.payload;
+    return undefined;
+  }
+
+  _setProperty(pt, p, value, msg) {
+    if (pt === 'msg') RED.setMessageProperty(msg, p, value, true);
+    else if (pt === 'flow') this.flow.set(p, value);
+    else if (pt === 'global') this.global.set(p, value);
+    else if (pt === 'payload') msg.payload = value;
+  }
+
+  _deleteProperty(pt, p, msg) {
+    if (pt === 'msg') {
+      const parts = p.split('.');
+      let target = msg;
+      for (let i = 0; i < parts.length - 1; i++) {
+        target = target?.[parts[i]];
+      }
+      if (target) delete target[parts[parts.length - 1]];
+    }
+  }
+
+  _convertValue(value, type, msg) {
+    switch (type) {
+      case 'str': return String(value);
+      case 'num': return Number(value);
+      case 'bool': return value === true || value === 'true';
+      case 'json': return JSON.parse(value);
+      case 'date': return this.clock.now();
+      case 'msg': return RED.getMessageProperty(msg, value);
+      case 'flow': return this.flow.get(value);
+      case 'global': return this.global.get(value);
+      case 'env': return process.env[value];
+      default: return value;
+    }
+  }
+
+  _evalSwitch(node, msg) {
+    const property = RED.getMessageProperty(msg, node.property);
+    for (let i = 0; i < (node.rules || []).length; i++) {
+      const rule = node.rules[i];
+      const check = this._evalSwitchRule(rule, property, msg);
+      if (check) {
+        const arr = new Array(node.outputs || 1).fill(undefined);
+        arr[i] = msg;
+        return arr;
+      }
+    }
+    return new Array(node.outputs || 1).fill(undefined);
+  }
+
+  _evalSwitchRule(rule, property, msg) {
+    const v = convertRuleValue(rule.v, rule.vt, msg, { flow: this.flow, global: this.global });
+    switch (rule.t) {
+      case 'eq': return String(property) === String(v);
+      case 'neq': return String(property) !== String(v);
+      case 'gt': return Number(property) > Number(v);
+      case 'gte': return Number(property) >= Number(v);
+      case 'lt': return Number(property) < Number(v);
+      case 'lte': return Number(property) <= Number(v);
+      case 'cont': return String(property).includes(String(v));
+      case 'true': return property === true;
+      case 'false': return property === false;
+      case 'null': return property == null;
+      case 'nnull': return property != null;
+      case 'else': return true;
+      default: return false;
+    }
+  }
+
+  async _evalLinkCall(node, msg, depth) {
+    let targetIds = [];
+    if (node.linkType === 'dynamic') {
+      const targetName = RED.getMessageProperty(msg, 'target');
+      const targetId = this.getNodeIdByName('link in', targetName);
+      if (!targetId) {
+        throw new Error(`Dynamic link call could not resolve link in "${targetName}"`);
+      }
+      targetIds = [targetId];
+    } else {
+      targetIds = node.links || [];
+    }
+
+    let outMsg = msg;
+    for (const targetId of targetIds) {
+      const terminals = [];
+      await this._visit(targetId, msg, depth + 1, terminals);
+      if (terminals.length > 0) {
+        outMsg = terminals[0];
+      }
+    }
+    return [outMsg];
+  }
+
+  _evalApiCurrentState(node, msg) {
+    const entityId = resolveTemplate(node.entity_id, msg);
+    const state = this.stateProvider.getState(entityId);
+    for (const prop of node.outputProperties || []) {
+      let value;
+      if (prop.valueType === 'entityState') {
+        value = state;
+      } else {
+        value = this._convertValue(prop.value, prop.valueType, msg);
+      }
+      this._setProperty(prop.propertyType || 'msg', prop.property, value, msg);
+    }
+    if (node.state_location) {
+      this._setProperty('msg', node.state_location, state, msg);
+    }
+    return [msg];
+  }
+
+  _evalApiRenderTemplate(node, msg) {
+    const rendered = this.templateProvider.render(node.name, node.entity_id, msg);
+    if (rendered !== undefined) {
+      this._setProperty(node.resultsLocationType || 'msg', node.resultsLocation, rendered, msg);
+    }
+    return [msg];
+  }
+
+  _evalTimeRangeSwitch(node, msg) {
+    // The timed strategy uses msg.__config set by a preceding function node.
+    const config = msg.__config || {};
+    const start = config.startTime;
+    const end = config.endTime;
+    if (!start || !end) {
+      return [undefined, msg];
+    }
+    const now = this.clock.now ? new Date(this.clock.now()) : new Date();
+    if (this._isInPeriod(now, start, end)) {
+      return [msg, undefined];
+    }
+    return [undefined, msg];
+  }
+
+  _isInPeriod(now, startStr, endStr) {
+    const toMinutes = (timeStr) => {
+      const [h, m = 0] = String(timeStr).split(':');
+      return Number(h) * 60 + Number(m);
+    };
+    const current = now.getHours() * 60 + now.getMinutes();
+    const start = toMinutes(startStr);
+    const end = toMinutes(endStr);
+    if (start <= end) {
+      return current >= start && current < end;
+    }
+    return current >= start || current < end;
+  }
+}
+
+module.exports = { FlowGraph };

--- a/test/lib/function-runner.js
+++ b/test/lib/function-runner.js
@@ -1,0 +1,119 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const RED = require('./red-util');
+const { ContextStore } = require('./context-store');
+
+class FunctionRunner {
+  /**
+   * @param {object} [options]
+   * @param {boolean} [options.captureStatus=true]
+   * @param {boolean} [options.captureWarnings=true]
+   * @param {boolean} [options.captureErrors=true]
+   * @param {boolean} [options.captureLogs=true]
+   */
+  constructor(options = {}) {
+    this.options = {
+      captureStatus: options.captureStatus !== false,
+      captureWarnings: options.captureWarnings !== false,
+      captureErrors: options.captureErrors !== false,
+      captureLogs: options.captureLogs !== false,
+    };
+    this.reset();
+  }
+
+  reset() {
+    this.status = [];
+    this.warnings = [];
+    this.errors = [];
+    this.logs = [];
+  }
+
+  /**
+   * Load a function node body from a flow export.
+   * @param {string} flowFile - relative path from project root, e.g. "node-red/02 strategy-full-stop.json"
+   * @param {string|{name?: string, id?: string}} nodeRef - function node name or {id}/{name}
+   * @returns {string}
+   */
+  loadFunctionCode(flowFile, nodeRef) {
+    const fullPath = path.resolve(__dirname, '../../', flowFile);
+    const flow = JSON.parse(fs.readFileSync(fullPath, 'utf8'));
+
+    const node = flow.find((n) => {
+      if (!n || n.type !== 'function') return false;
+      if (typeof nodeRef === 'string') return n.name === nodeRef || n.id === nodeRef;
+      if (nodeRef.id) return n.id === nodeRef.id;
+      if (nodeRef.name) return n.name === nodeRef.name;
+      return false;
+    });
+
+    if (!node) {
+      throw new Error(
+        `Function node ${JSON.stringify(nodeRef)} not found in ${flowFile}`
+      );
+    }
+
+    return node.func;
+  }
+
+  /**
+   * Execute a function node.
+   * @param {object} params
+   * @param {string} params.flowFile
+   * @param {string|object} params.node - function node name or {name, id}
+   * @param {object} [params.msg={}]
+   * @param {ContextStore} [params.context]
+   * @param {ContextStore} [params.flow]
+   * @param {ContextStore} [params.global]
+   * @returns {unknown} - the return value from the function node (may be array)
+   */
+  run({ flowFile, node: nodeRef, msg = {}, context, flow, global }) {
+    this.reset();
+    const code = flowFile
+      ? this.loadFunctionCode(flowFile, nodeRef)
+      : this.loadFunctionCodeByNode(nodeRef);
+    return this.execute(code, nodeRef, msg, context, flow, global);
+  }
+
+  loadFunctionCodeByNode(node) {
+    if (!node || typeof node.func !== 'string') {
+      throw new Error('Function node object with func string required');
+    }
+    return node.func;
+  }
+
+  execute(code, nodeRef, msg = {}, context, flow, global) {
+    const contextStore = context || new ContextStore();
+    const flowStore = flow || new ContextStore();
+    const globalStore = global || new ContextStore();
+
+    const fn = new Function('msg', 'node', 'context', 'flow', 'global', 'RED', code);
+
+    const nodeName = typeof nodeRef === 'string'
+      ? nodeRef
+      : (nodeRef?.name || nodeRef?.id || 'unknown');
+    const nodeId = typeof nodeRef === 'object' && nodeRef?.id ? nodeRef.id : nodeName;
+
+    const nodeMock = {
+      status: this.options.captureStatus ? (obj) => { this.status.push(obj); } : () => {},
+      warn: this.options.captureWarnings ? (text) => { this.warnings.push(text); } : () => {},
+      error: this.options.captureErrors ? (text, message) => { this.errors.push({ text, msg: message }); } : () => {},
+      log: this.options.captureLogs ? (text) => { this.logs.push(text); } : () => {},
+    };
+
+    const thisObj = {
+      __node__: { id: nodeId, name: nodeName },
+      env: {
+        get: (key) => flowStore.get(key),
+      },
+      msg,
+    };
+
+    const REDMock = { util: RED };
+
+    return fn.call(thisObj, msg, nodeMock, contextStore, flowStore, globalStore, REDMock);
+  }
+}
+
+module.exports = { FunctionRunner };

--- a/test/lib/ha-state-mock.js
+++ b/test/lib/ha-state-mock.js
@@ -1,0 +1,51 @@
+'use strict';
+
+// Simple Mustache-like resolver for {{property}} tokens.
+function resolveTemplate(template, msg) {
+  if (typeof template !== 'string') return template;
+  return template.replace(/\{\{\s*([\w.]+)\s*\}\}/g, (_, path) => {
+    const value = path.split('.').reduce((obj, key) => (obj != null ? obj[key] : undefined), msg);
+    return value === undefined ? '' : String(value);
+  });
+}
+
+class StateProvider {
+  /**
+   * @param {Map<string, string|number>|Function} [resolver]
+   */
+  constructor(resolver) {
+    if (typeof resolver === 'function') {
+      this.resolve = resolver;
+    } else if (resolver instanceof Map) {
+      this.resolve = (id) => resolver.get(id) ?? '';
+    } else {
+      this.resolve = () => '';
+    }
+  }
+
+  getState(entityId) {
+    return this.resolve(entityId) ?? '';
+  }
+}
+
+class TemplateProvider {
+  /**
+   * @param {Record<string, Function>} templates
+   */
+  constructor(templates = {}) {
+    this.templates = templates;
+  }
+
+  render(name, entityId, msg) {
+    if (this.templates[name]) {
+      return this.templates[name](entityId, msg, resolveTemplate);
+    }
+    return '';
+  }
+}
+
+module.exports = {
+  resolveTemplate,
+  StateProvider,
+  TemplateProvider,
+};

--- a/test/lib/red-util.js
+++ b/test/lib/red-util.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('@node-red/util').util;

--- a/test/support/init-flow.js
+++ b/test/support/init-flow.js
@@ -15,8 +15,8 @@ class Initializer {
   }
 
   /**
-   * Run the branch-101 "Custom logger" function, which also initializes
-   * `phasePowerAllocator`, `logger`, and `unhandledException` as globals.
+   * Run the "Custom logger" function, which initializes `logger` and
+   * `unhandledException` as globals.
    */
   initialize() {
     const runner = new FunctionRunner({ captureStatus: false, captureWarnings: false, captureErrors: false, captureLogs: false });

--- a/test/support/init-flow.js
+++ b/test/support/init-flow.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const { FunctionRunner } = require('../lib/function-runner');
+const { ContextStore } = require('../lib/context-store');
+
+class Initializer {
+  /**
+   * @param {object} options
+   * @param {ContextStore} [options.global]
+   * @param {boolean} [options.debugMode=false]
+   */
+  constructor({ global: globalStore, debugMode = false } = {}) {
+    this.global = globalStore || new ContextStore();
+    this.debugMode = debugMode;
+  }
+
+  /**
+   * Run the branch-101 "Custom logger" function, which also initializes
+   * `phasePowerAllocator`, `logger`, and `unhandledException` as globals.
+   */
+  initialize() {
+    const runner = new FunctionRunner({ captureStatus: false, captureWarnings: false, captureErrors: false, captureLogs: false });
+    runner.run({
+      flowFile: 'node-red/01 start-flow.json',
+      node: 'Custom logger',
+      msg: {},
+      global: this.global,
+    });
+    this.global.set('debug_mode', this.debugMode);
+  }
+
+  /**
+   * Provide a no-op logger global for tests that don't need the real one.
+   */
+  useNoopLogger() {
+    this.global.set('logger', () => {});
+    this.global.set('unhandledException', () => {});
+  }
+}
+
+module.exports = { Initializer };

--- a/test/unit/strategies/full-stop.test.js
+++ b/test/unit/strategies/full-stop.test.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { FunctionRunner } = require('../../lib/function-runner');
+
+const { Initializer } = require('../../support/init-flow');
+
+describe('Full stop strategy', () => {
+  it('stops every battery at 0 W', () => {
+    const initializer = new Initializer();
+    initializer.useNoopLogger();
+
+    const runner = new FunctionRunner();
+    const msg = {
+      batteries: [
+        { id: 'M1', power: 1200 },
+        { id: 'M2', power: -800 },
+      ],
+    };
+    const result = runner.run({
+      flowFile: 'node-red/02 strategy-full-stop.json',
+      node: 'Stop all batteries',
+      msg,
+      global: initializer.global,
+    });
+
+    assert.deepEqual(result.solutions, [
+      { id: 'M1', mode: 'stop', power: 0 },
+      { id: 'M2', mode: 'stop', power: 0 },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
This PR backports the test harness that I intend to include in `101-phase-protection-peak-shaving` to `main`, stripping out the tests and expectations that depend on per-phase peak-shaving logic that does not yet exist here. 

The intent is that this should be straightforward to review + merge because it is test only, and it establishes a baseline so that it's easier to spot behavior changes / expectation changes / regressions in future PRs. 

## What changed
- Added the Node-RED flow harness (`test/lib/*`, `test/support/*`, fixtures).
- Added integration tests for the strategy flows that already exist on `main`:
  - Charge, Sell, Full stop, Partials, Self-consumption.
- Added a unit test for the Full stop strategy.

## Relative to the commit on 101-phase-protection-peak-shaving
- Removed phase-only tests and fixtures that target the `Phase command limits` and `Phase protection guard` nodes (not on `main`).
- Removed the phase-throttling cases from the Charge and Sell integration tests.
- Preserved `phase_protection` fields in remaining test payloads and added comments explaining they are currently ignored on `main` but will be used by the upcoming phase-protection PR.
- Updated `package.json` test scripts to use `find` so tests are discovered consistently across shells (the original `**/*.test.js` glob did not recurse reliably on zsh/macOS).

## Test results
```
▶ Charge strategy integration
  ✔ charges at max power without limits (3.934916ms)
✔ Charge strategy integration (4.563958ms)
▶ Full stop strategy integration
  ✔ walks from link in to link out and stops every battery (3.110834ms)
✔ Full stop strategy integration (4.075042ms)
▶ Partials strategy integration
  ✔ peak shaves import by discharging when grid power exceeds import limit (4.16625ms)
  ✔ peak shaves export by charging when grid power exceeds export limit (1.382208ms)
✔ Partials strategy integration (6.559709ms)
▶ Self-consumption strategy integration
  ✔ charges surplus power when exporting to the grid (7.270834ms)
  ✔ discharges to cover import when drawing from the grid (1.558375ms)
✔ Self-consumption strategy integration (9.870166ms)
▶ Sell strategy integration
  ✔ discharges at max power without limits (4.374958ms)
✔ Sell strategy integration (5.035584ms)
▶ Full stop strategy
  ✔ stops every battery at 0 W (2.135125ms)
✔ Full stop strategy (2.789125ms)
ℹ tests 8
ℹ suites 6
ℹ pass 8
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 194.983708
```

## Scope
No production Node-RED flow files are modified; this PR adds only test code, dependency metadata, a Makefile, and `.gitignore` entries.
